### PR TITLE
Lra 912 room ready -  rspec tests for zones controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@
 
 # files created from js scripts
 webcheckout_api/files
+
+spec/cassettes

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -52,6 +52,7 @@ class ZonesController < ApplicationController
 
   # DELETE /zones/1 or /zones/1.json
   def destroy
+    @zone.buildings.delete_all
     @zone.destroy!
 
     respond_to do |format|

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -56,7 +56,7 @@ class ZonesController < ApplicationController
     @zone.destroy!
 
     respond_to do |format|
-      format.html { redirect_to zones_url, notice: "Zone was successfully destroyed." }
+      format.html { redirect_to zones_url, notice: "Zone was successfully deleted." }
       format.json { head :no_content }
     end
   end

--- a/app/controllers/zones_controller.rb
+++ b/app/controllers/zones_controller.rb
@@ -41,7 +41,7 @@ class ZonesController < ApplicationController
   def update
     respond_to do |format|
       if @zone.update(zone_params)
-        format.html { redirect_to zone_url(@zone), notice: "Zone was successfully updated." }
+        format.html { redirect_to zones_path, notice: "Zone was successfully updated." }
         format.json { render :show, status: :ok, location: @zone }
       else
         format.html { render :edit, status: :unprocessable_entity }

--- a/app/views/zones/_form.html.erb
+++ b/app/views/zones/_form.html.erb
@@ -18,5 +18,6 @@
 
   <div>
     <%= form.submit %>
+    <%= link_to "Cancel", zones_path, class: "text-primary cancel-button" %>
   </div>
 <% end %>

--- a/app/views/zones/edit.html.erb
+++ b/app/views/zones/edit.html.erb
@@ -2,5 +2,4 @@
   <h1>Editing <%= @zone.name %></h1>
 
   <%= render "form", zone: @zone %>
-  <%= link_to "Cancel", zone_path(@zone)%>
 </div>

--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -10,7 +10,12 @@
         <div class="card m-2" style="width: 18rem;">
           <div class="card-body">
             <h5 class="card-title"><%= render zone %></h5>
-            <%= link_to "Zone Details", zone, class: "card-link" %>
+            <div class="d-flex flex-row justify-content-between align-items-center gap-3">
+              <%= link_to "Zone Details", zone, class: "card-link" %>
+              <%= link_to edit_zone_path(zone), 'aria-label': "edit_#{zone.id}" do %>
+                <i class="bi bi-pencil-square text-primary"></i>
+              <% end %>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -1,5 +1,4 @@
 <div class="p-5 m-5">
-  <p style="color: green"><%= notice %></p>
   <div class="container-fluid" id="zones">
     <div class="d-flex justify-content-between">
       <h1>All Zones</h1>
@@ -10,13 +9,13 @@
         <div class="card m-2" style="width: 18rem;">
           <div class="card-body">
             <h5 class="card-title"><%= render zone %></h5>
-            <div class="d-flex flex-row justify-content-between align-items-center gap-3">
+            <div class="d-flex flex-row justify-content-between align-items-center">
               <%= link_to "Zone Details", zone, class: "card-link" %>
-              <div>
+              <div class="d-flex flex-row justify-content-center align-items-center gap-3">
                 <%= link_to edit_zone_path(zone), 'aria-label': "edit_#{zone.id}" do %>
                   <i class="bi bi-pencil-square text-primary"></i>
                 <% end %>
-                <%= link_to zone_path(zone), data: { turbo_confirm: "Are you sure you want to delete this zone?" , turbo_method: :delete } do %>
+                <%= link_to zone_path(zone), 'aria-label': "delete_#{zone.id}", data: { turbo_confirm: "Are you sure you want to delete this zone?" , turbo_method: :delete } do %>
                   <i class="bi bi-trash-fill text-danger"></i>
                 <% end %>
               </div>

--- a/app/views/zones/index.html.erb
+++ b/app/views/zones/index.html.erb
@@ -12,9 +12,14 @@
             <h5 class="card-title"><%= render zone %></h5>
             <div class="d-flex flex-row justify-content-between align-items-center gap-3">
               <%= link_to "Zone Details", zone, class: "card-link" %>
-              <%= link_to edit_zone_path(zone), 'aria-label': "edit_#{zone.id}" do %>
-                <i class="bi bi-pencil-square text-primary"></i>
-              <% end %>
+              <div>
+                <%= link_to edit_zone_path(zone), 'aria-label': "edit_#{zone.id}" do %>
+                  <i class="bi bi-pencil-square text-primary"></i>
+                <% end %>
+                <%= link_to zone_path(zone), data: { turbo_confirm: "Are you sure you want to delete this zone?" , turbo_method: :delete } do %>
+                  <i class="bi bi-trash-fill text-danger"></i>
+                <% end %>
+              </div>
             </div>
           </div>
         </div>

--- a/app/views/zones/new.html.erb
+++ b/app/views/zones/new.html.erb
@@ -1,6 +1,6 @@
 <div class="p-3">
 
-  <h1>Add new zone</h1>
+  <h1>Add New Zone</h1>
 
   <%= render "form", zone: @zone %>
   <%= link_to "Cancel", zones_path, class: "text-primary cancel-button" %> 

--- a/app/views/zones/new.html.erb
+++ b/app/views/zones/new.html.erb
@@ -1,7 +1,4 @@
 <div class="p-3">
-
   <h1>Add New Zone</h1>
-
   <%= render "form", zone: @zone %>
-  <%= link_to "Cancel", zones_path, class: "text-primary cancel-button" %> 
 </div>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -29,7 +29,7 @@ en:
         subject: "Password Changed"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
-      success: "Successfully authenticated from %{kind} account."
+      success: "Signed in successfully."
     passwords:
       no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
       send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."

--- a/spec/system/common_attributes_controller_spec.rb
+++ b/spec/system/common_attributes_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe CommonAttribute, type: :system do
   context 'edit a common attribute' do
     let!(:common_attribute) { FactoryBot.create(:common_attribute) }
 
-    it 'click an edit icon and go to edit page' do
+    it 'click on edit icon and go to edit page' do
       VCR.use_cassette "common_attribute" do
         visit common_attributes_path
         sleep 2
@@ -35,7 +35,7 @@ RSpec.describe CommonAttribute, type: :system do
       end
     end
 
-    it 'click an edit icon and cancel editing' do
+    it 'click on edit icon and cancel editing' do
       VCR.use_cassette "common_attribute" do
         visit common_attributes_path
         sleep 2
@@ -47,7 +47,7 @@ RSpec.describe CommonAttribute, type: :system do
       end
     end
 
-    it 'click an edit icon and update description' do
+    it 'click on edit icon and update description' do
       VCR.use_cassette "common_attribute" do
         visit common_attributes_path
         sleep 2
@@ -61,7 +61,7 @@ RSpec.describe CommonAttribute, type: :system do
       end
     end
 
-    it 'click an delete icon and cancel the alert messege' do
+    it 'click on delete icon and cancel the alert messege' do
       VCR.use_cassette "common_attribute" do
         visit common_attributes_path
         sleep 2
@@ -75,7 +75,7 @@ RSpec.describe CommonAttribute, type: :system do
       end
     end
 
-    it 'click an cancel icon and accept the alert message' do
+    it 'click on cancel icon and accept the alert message' do
       VCR.use_cassette "common_attribute" do
         visit common_attributes_path
         sleep 2
@@ -85,7 +85,7 @@ RSpec.describe CommonAttribute, type: :system do
         expect(text).to eq 'Are you sure you want to delete this Common Attribute?'
         page.driver.browser.switch_to.alert.accept
         sleep 2
-        expect(page).to have_content("Common attribute was successfully destroyed.")
+        expect(page).to have_content("Common attribute was successfully deleted.")
       end
     end
   end

--- a/spec/system/shib_login_spec.rb
+++ b/spec/system/shib_login_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Controllers", type: :request do
       user = FactoryBot.create(:user)
       mock_login(user)
       follow_redirect!
-      expect(response.body).to include("Welcome")
+      expect(response.body).to include("Signed in successfully.")
     end
   end
 

--- a/spec/system/zones_controller_spec.rb
+++ b/spec/system/zones_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Zone, type: :system do
         sleep 2
         fill_in "Name", with: "Zone A"
         click_on "Create Zone"
-        sleep 5
+        sleep 2
         expect(page).to have_content("Zone was successfully created.")
       end
     end
@@ -85,7 +85,7 @@ RSpec.describe Zone, type: :system do
         expect(text).to eq 'Are you sure you want to delete this zone?'
         page.driver.browser.switch_to.alert.accept
         sleep 2
-        expect(page).to have_content("zone was successfully deleted.")
+        expect(page).to have_content("Zone was successfully deleted.")
       end
     end
   end

--- a/spec/system/zones_controller_spec.rb
+++ b/spec/system/zones_controller_spec.rb
@@ -31,63 +31,63 @@ RSpec.describe Zone, type: :system do
         sleep 2
         find(:css, 'i.bi.bi-pencil-square.text-primary').click
         sleep 2
-        expect(page).to have_content("Edit zone")
+        expect(page).to have_content("Editing Zone")
       end
     end
 
-#     it 'click an edit icon and cancel editing' do
-#       VCR.use_cassette "zone" do
-#         visit zones_path
-#         sleep 2
-#         find(:css, 'i.bi.bi-pencil-square.text-primary').click
-#         sleep 2
-#         expect(page).to have_content("Edit zone")
-#         click_on "Cancel"
-#         expect(page).to have_content(zone.description)
-#       end
-#     end
+    it 'click an edit icon and cancel editing' do
+      VCR.use_cassette "zone" do
+        visit zones_path
+        sleep 2
+        find(:css, 'i.bi.bi-pencil-square.text-primary').click
+        sleep 2
+        expect(page).to have_content("Editing Zone")
+        click_on "Cancel"
+        expect(page).to have_content(zone.name)
+      end
+    end
 
-#     it 'click an edit icon and update description' do
-#       VCR.use_cassette "zone" do
-#         visit zones_path
-#         sleep 2
-#         find(:css, 'i.bi.bi-pencil-square.text-primary').click
-#         sleep 2
-#         expect(page).to have_content("Edit zone")
-#         fill_in "Description", with: zone.description + "edited"
-#         click_on "Update"
-#         sleep 2
-#         expect(page).to have_content(zone.description + "edited")
-#       end
-#     end
+    it 'click an edit icon and update name' do
+      VCR.use_cassette "zone" do
+        visit zones_path
+        sleep 2
+        find(:css, 'i.bi.bi-pencil-square.text-primary').click
+        sleep 2
+        expect(page).to have_content("Editing Zone")
+        fill_in "Name", with: zone.name + "edited"
+        click_on "Update"
+        sleep 2
+        expect(page).to have_content(zone.name + "edited")
+      end
+    end
 
-#     it 'click an delete icon and cancel the alert messege' do
-#       VCR.use_cassette "zone" do
-#         visit zones_path
-#         sleep 2
-#         find(:css, 'i.bi.bi-trash-fill.text-danger').click
-#         sleep 2
-#         text = page.driver.browser.switch_to.alert.text
-#         expect(text).to eq 'Are you sure you want to Delete this zone?'
-#         page.driver.browser.switch_to.alert.dismiss
-#         sleep 2
-#         expect(page).to have_content(zone.description)
-#       end
-#     end
+    it 'click an delete icon and cancel the alert message' do
+      VCR.use_cassette "zone" do
+        visit zones_path
+        sleep 2
+        find(:css, 'i.bi.bi-trash-fill.text-danger').click
+        sleep 2
+        text = page.driver.browser.switch_to.alert.text
+        expect(text).to eq 'Are you sure you want to delete this zone?'
+        page.driver.browser.switch_to.alert.dismiss
+        sleep 2
+        expect(page).to have_content(zone.name)
+      end
+    end
 
-#     it 'click an cancel icon and accept the alert message' do
-#       VCR.use_cassette "zone" do
-#         visit zones_path
-#         sleep 2
-#         find(:css, 'i.bi.bi-trash-fill.text-danger').click
-#         sleep 2
-#         text = page.driver.browser.switch_to.alert.text
-#         expect(text).to eq 'Are you sure you want to delete this zone?'
-#         page.driver.browser.switch_to.alert.accept
-#         sleep 2
-#         expect(page).to have_content("zone was successfully destroyed.")
-#       end
-#     end
-#   end
+    it 'click an cancel icon and accept the alert message' do
+      VCR.use_cassette "zone" do
+        visit zones_path
+        sleep 2
+        find(:css, 'i.bi.bi-trash-fill.text-danger').click
+        sleep 2
+        text = page.driver.browser.switch_to.alert.text
+        expect(text).to eq 'Are you sure you want to delete this zone?'
+        page.driver.browser.switch_to.alert.accept
+        sleep 2
+        expect(page).to have_content("zone was successfully deleted.")
+      end
+    end
+  end
   
 end

--- a/spec/system/zones_controller_spec.rb
+++ b/spec/system/zones_controller_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+RSpec.describe Zone, type: :system do
+
+  before do
+		user = FactoryBot.create(:user)
+		mock_login(user)
+    allow_any_instance_of(User).to receive(:membership).and_return(['lsa-roomready-admins'])
+	end
+
+	context 'create a new zone' do
+    it 'fills out the form and submits it' do
+      VCR.use_cassette "zone" do
+        visit zones_path
+        click_on "Add New Zone"
+        sleep 2
+        fill_in "Name", with: "Zone A"
+        click_on "Create Zone"
+        sleep 5
+        expect(page).to have_content("Zone was successfully created.")
+      end
+    end
+  end
+
+  context 'edit a zone' do
+    let!(:zone) { FactoryBot.create(:zone) }
+
+    it 'click an edit icon and go to edit page' do
+      VCR.use_cassette "zone" do
+        visit zones_path
+        sleep 2
+        find(:css, 'i.bi.bi-pencil-square.text-primary').click
+        sleep 2
+        expect(page).to have_content("Edit zone")
+      end
+    end
+
+#     it 'click an edit icon and cancel editing' do
+#       VCR.use_cassette "zone" do
+#         visit zones_path
+#         sleep 2
+#         find(:css, 'i.bi.bi-pencil-square.text-primary').click
+#         sleep 2
+#         expect(page).to have_content("Edit zone")
+#         click_on "Cancel"
+#         expect(page).to have_content(zone.description)
+#       end
+#     end
+
+#     it 'click an edit icon and update description' do
+#       VCR.use_cassette "zone" do
+#         visit zones_path
+#         sleep 2
+#         find(:css, 'i.bi.bi-pencil-square.text-primary').click
+#         sleep 2
+#         expect(page).to have_content("Edit zone")
+#         fill_in "Description", with: zone.description + "edited"
+#         click_on "Update"
+#         sleep 2
+#         expect(page).to have_content(zone.description + "edited")
+#       end
+#     end
+
+#     it 'click an delete icon and cancel the alert messege' do
+#       VCR.use_cassette "zone" do
+#         visit zones_path
+#         sleep 2
+#         find(:css, 'i.bi.bi-trash-fill.text-danger').click
+#         sleep 2
+#         text = page.driver.browser.switch_to.alert.text
+#         expect(text).to eq 'Are you sure you want to Delete this zone?'
+#         page.driver.browser.switch_to.alert.dismiss
+#         sleep 2
+#         expect(page).to have_content(zone.description)
+#       end
+#     end
+
+#     it 'click an cancel icon and accept the alert message' do
+#       VCR.use_cassette "zone" do
+#         visit zones_path
+#         sleep 2
+#         find(:css, 'i.bi.bi-trash-fill.text-danger').click
+#         sleep 2
+#         text = page.driver.browser.switch_to.alert.text
+#         expect(text).to eq 'Are you sure you want to delete this zone?'
+#         page.driver.browser.switch_to.alert.accept
+#         sleep 2
+#         expect(page).to have_content("zone was successfully destroyed.")
+#       end
+#     end
+#   end
+  
+end

--- a/spec/system/zones_controller_spec.rb
+++ b/spec/system/zones_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Zone, type: :system do
   context 'edit a zone' do
     let!(:zone) { FactoryBot.create(:zone) }
 
-    it 'click an edit icon and go to edit page' do
+    it 'click on edit icon and go to edit page' do
       VCR.use_cassette "zone" do
         visit zones_path
         sleep 2
@@ -35,7 +35,7 @@ RSpec.describe Zone, type: :system do
       end
     end
 
-    it 'click an edit icon and cancel editing' do
+    it 'click on edit icon and cancel editing' do
       VCR.use_cassette "zone" do
         visit zones_path
         sleep 2
@@ -47,7 +47,7 @@ RSpec.describe Zone, type: :system do
       end
     end
 
-    it 'click an edit icon and update name' do
+    it 'click on edit icon and update name' do
       VCR.use_cassette "zone" do
         visit zones_path
         sleep 2
@@ -61,7 +61,7 @@ RSpec.describe Zone, type: :system do
       end
     end
 
-    it 'click an delete icon and cancel the alert message' do
+    it 'click on delete icon and cancel the alert message' do
       VCR.use_cassette "zone" do
         visit zones_path
         sleep 2
@@ -75,7 +75,7 @@ RSpec.describe Zone, type: :system do
       end
     end
 
-    it 'click an cancel icon and accept the alert message' do
+    it 'click on cancel icon and accept the alert message' do
       VCR.use_cassette "zone" do
         visit zones_path
         sleep 2

--- a/spec/system/zones_user_is_not_authorized_spec.rb
+++ b/spec/system/zones_user_is_not_authorized_spec.rb
@@ -8,22 +8,22 @@ RSpec.describe CommonAttribute, type: :system do
     # user.membership is [] - user should not have access to any CommonAttribute routes
 	end
 
-	context 'create a new common attribute' do
+	context 'create a new zone' do
     it 'returns a "You are not authorized to perform this action." message' do
-      VCR.use_cassette "common_attribute" do
-        visit common_attributes_path
+      VCR.use_cassette "zone" do
+        visit zones_path
         sleep 2
         expect(page).to have_content("You are not authorized to perform this action.")
       end
     end
   end
 
-  context 'edit a common attribute' do
-    let!(:common_attribute) { FactoryBot.create(:common_attribute) }
+  context 'edit a zone' do
+    let!(:zone) { FactoryBot.create(:zone) }
 
     it 'returns a "You are not authorized to perform this action." message' do
-      VCR.use_cassette "common_attribute" do
-        visit edit_common_attribute_path(common_attribute)
+      VCR.use_cassette "zone" do
+        visit edit_zone_path(zone)
         sleep 2
         expect(page).to have_content("You are not authorized to perform this action.")
       end

--- a/spec/system/zones_user_is_not_authorized_spec.rb
+++ b/spec/system/zones_user_is_not_authorized_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe CommonAttribute, type: :system do
+
+  before do
+		user = FactoryBot.create(:user)
+		mock_login(user)
+    # user.membership is [] - user should not have access to any CommonAttribute routes
+	end
+
+	context 'create a new common attribute' do
+    it 'returns a "You are not authorized to perform this action." message' do
+      VCR.use_cassette "common_attribute" do
+        visit common_attributes_path
+        sleep 2
+        expect(page).to have_content("You are not authorized to perform this action.")
+      end
+    end
+  end
+
+  context 'edit a common attribute' do
+    let!(:common_attribute) { FactoryBot.create(:common_attribute) }
+
+    it 'returns a "You are not authorized to perform this action." message' do
+      VCR.use_cassette "common_attribute" do
+        visit edit_common_attribute_path(common_attribute)
+        sleep 2
+        expect(page).to have_content("You are not authorized to perform this action.")
+      end
+    end
+  end
+  
+end


### PR DESCRIPTION
This pull request has rspec tests for the Zones controller:

- spec/system/zones_controller_spec.rb
- spec/system/zones_user_is_not_authorized_spec.rb


Review the code and run tests with these commands:

- SHOW_BROWSER=true rspec spec/system/zones_controller_spec.rb
or
- rspec spec/system/zones_controller_spec.rb

and
- SHOW_BROWSER=true rspec spec/system/zones_user_is_not_authorized_spec.rb
or
- rspec spec/system/zones_user_is_not_authorized_spec.rb

Also, I edited the Zones pages a little

- Added edit and delete buttons to zones' cards
- The edit link goes directly to the edit form, and then back to the zones index page.
- Delete button removes buildings from the zone and deletes that zone
- some notices were edited and typos were fixed

To test

- Pull the branch
- Look at the Zones pages (Base -> Zones in the header menu)
- Check create/edit/delete functions
- Zones' 'Zone Details' link will show the zone buildings - will be done in a different branch/ticket
- Then run rspec tests