### PR TITLE
Refactor authorization process

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,6 @@ class ApplicationController < ActionController::Base
   # rescue_from Exception, with: :render_500
   include Pundit::Authorization
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
-  before_action :set_membership
   after_action :verify_authorized, unless: :devise_controller?
   include ApplicationHelper
 
@@ -22,13 +21,17 @@ class ApplicationController < ActionController::Base
   def after_sign_in_path_for(resource)
     if $baseURL.present?
       $baseURL
-    elsif session[:user_memberships].present?
+    elsif session[:role] == "developer" || session[:role] == "admin"
       dashboard_path
-    elsif is_rover?(resource)
+    elsif session[:role] == "rover"
       welcome_rovers_path
     else
       root_path
     end
+  end
+
+  def pundit_user
+    { user: current_user, role: session[:role] }
   end
 
   def render_404
@@ -46,14 +49,4 @@ class ApplicationController < ActionController::Base
     end
   end
 
-  private
-
-    def set_membership
-      if user_signed_in?
-        current_user.membership = session[:user_memberships]
-        current_user.admin = session[:user_admin]
-      else
-        new_user_session_path
-      end
-    end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -42,14 +42,15 @@ def set_user
   if @user
     session[:user_email] = @user.email
 
-    membership = []
-    access_groups = ['lsa-roomready-admins', 'lsa-roomready-developers']
-    access_groups.each do |group|
-      if  LdapLookup.is_member_of_group?(@user.uniqname, group)
-        membership.append(group)
-      end
+    if LdapLookup.is_member_of_group?(@user.uniqname, 'lsa-roomready-developers')
+      session[:role] = "developer"
+    elsif LdapLookup.is_member_of_group?(@user.uniqname, 'lsa-roomready-admins')
+      session[:role] = "admin"
+    elsif  Rover.exists?(uniqname: @user.uniqname)
+      session[:role] = "rover"
+    else
+      session[:role] = "none"
     end
-    session[:user_memberships] = membership
   end
 end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,9 +2,9 @@ module ApplicationHelper
 
   def root_path
     if user_signed_in?
-      if is_admin?(current_user)
+      if is_admin?
         dashboard_path
-      elsif is_rover?(current_user)
+      elsif is_rover?
         welcome_rovers_path
       else
         all_root_path
@@ -88,12 +88,12 @@ module ApplicationHelper
     field.to_date.strftime("%B %d, %Y") unless field.blank?
   end
 
-  def is_rover?(current_user)
-    Rover.exists?(uniqname: current_user.uniqname)
+  def is_rover?
+    session[:role] == "rover"
   end
 
-  def is_admin?(user)
-    user.membership.present?
+  def is_admin?
+    session[:role] == "developer" || session[:role] == "admin"
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,5 +26,4 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:saml]
 
-  attr_accessor :role
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,5 +26,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:saml]
 
-  attr_accessor :membership, :admin, :rover
+  attr_accessor :role
 end

--- a/app/policies/announcement_policy.rb
+++ b/app/policies/announcement_policy.rb
@@ -1,15 +1,15 @@
 class AnnouncementPolicy < ApplicationPolicy
   
     def index?
-      user_in_admin_group?
+      is_admin?
     end
   
     def show?
-      user_in_admin_group?
+      is_admin?
     end
     
     def update?
-      user_in_admin_group?
+      is_admin?
     end
     
     def edit?

--- a/app/policies/app_preference_policy.rb
+++ b/app/policies/app_preference_policy.rb
@@ -1,14 +1,14 @@
 class AppPreferencePolicy < ApplicationPolicy
   def index?
-    user_in_dev_group?
+    is_developer?
   end
 
   def show?
-    user_in_dev_group?
+    is_developer?
   end
 
   def create?
-    user_in_dev_group?
+    is_developer?
   end
 
   def new?
@@ -16,7 +16,7 @@ class AppPreferencePolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_dev_group?
+    is_developer?
   end
   
   def edit?
@@ -24,15 +24,15 @@ class AppPreferencePolicy < ApplicationPolicy
   end
 
   def destroy?
-    user_in_dev_group?
+    is_developer?
   end
 
   def configure_prefs?
-    user_in_admin_group?
+    is_admin?
   end
 
   def save_configured_prefs?
-    user_in_admin_group?
+    is_admin?
   end
 
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class ApplicationPolicy
-  attr_reader :user, :admin, :record
+  attr_reader :user, :role, :record
 
   def initialize(context, record)
     @user = context[:user]
     @role = context[:role]
     @record = record
+
   end
 
   def index?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 class ApplicationPolicy
-  attr_reader :user, :record
+  attr_reader :user, :admin, :record
 
-  def initialize(user, record)
-    @user = user
+  def initialize(context, record)
+    @user = context[:user]
+    @role = context[:role]
     @record = record
   end
 
@@ -36,20 +37,16 @@ class ApplicationPolicy
     false
   end
 
-  def user_in_admin_group?
-    # binding.pry
-    # admin_group = ['lsa-roomready-admins']
-    # user.membership && (user.membership & admin_group).any?
-    @user.membership && @user.membership.include?('lsa-roomready-admins')
+  def is_admin?
+    @role == "admin" || @role == "developer"
   end
 
-  def user_in_dev_group?
-    admin_group = ['lsa-roomready-developers']
-    user.membership && (user.membership & admin_group).any?
+  def is_developer?
+    @role == "developer"
   end
 
   def is_rover?
-    Rover.exists?(uniqname: user.uniqname)
+    @role == "rover"
   end
 
   class Scope

--- a/app/policies/building_policy.rb
+++ b/app/policies/building_policy.rb
@@ -1,14 +1,14 @@
 class BuildingPolicy < ApplicationPolicy
   def index?
-    user_in_admin_group? || is_rover?
+    is_admin? || is_rover?
   end
 
   def show?
-    user_in_admin_group? || is_rover?
+    is_admin? || is_rover?
   end
 
   def create?
-    user_in_admin_group?
+    is_admin?
   end
 
   def new?
@@ -16,7 +16,7 @@ class BuildingPolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_admin_group?
+    is_admin?
   end
   
   def edit?
@@ -24,6 +24,6 @@ class BuildingPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user_in_admin_group?
+    is_admin?
   end
 end

--- a/app/policies/common_attribute_policy.rb
+++ b/app/policies/common_attribute_policy.rb
@@ -1,10 +1,10 @@
 class CommonAttributePolicy < ApplicationPolicy
   def index?
-    user_in_admin_group?
+    is_admin?
   end
 
   def create?
-    user_in_admin_group?
+    is_admin?
   end
 
   def new?
@@ -12,7 +12,7 @@ class CommonAttributePolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_admin_group?
+    is_admin?
   end
   
   def edit?
@@ -20,6 +20,6 @@ class CommonAttributePolicy < ApplicationPolicy
   end
 
   def destroy?
-    user_in_admin_group?
+    is_admin?
   end
 end

--- a/app/policies/common_attribute_state_policy.rb
+++ b/app/policies/common_attribute_state_policy.rb
@@ -1,6 +1,6 @@
 class CommonAttributeStatePolicy < ApplicationPolicy
   def create?
-    user_in_admin_group?
+   is_admin?
   end
 
   def new?

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -1,14 +1,14 @@
 class RoomPolicy < ApplicationPolicy
   def index?
-    user_in_admin_group?
+    is_admin?
   end
 
   def show?
-    user_in_admin_group?
+    is_admin?
   end
 
   def create?
-    user_in_admin_group?
+    is_admin?
   end
 
   def new?
@@ -16,7 +16,7 @@ class RoomPolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_admin_group?
+    is_admin?
   end
   
   def edit?
@@ -24,6 +24,6 @@ class RoomPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user_in_admin_group?
+    is_admin?
   end
 end

--- a/app/policies/rover_policy.rb
+++ b/app/policies/rover_policy.rb
@@ -1,15 +1,15 @@
 class RoverPolicy < ApplicationPolicy
   
   def index?
-    user_in_admin_group?
+    is_admin?
   end
 
   def show?
-    user_in_admin_group?
+    is_admin?
   end
 
   def create?
-    user_in_admin_group?
+    is_admin?
   end
 
   def new?
@@ -17,7 +17,7 @@ class RoverPolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_admin_group?
+    is_admin?
   end
   
   def edit?
@@ -25,7 +25,7 @@ class RoverPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user_in_admin_group?
+    is_admin?
   end
   
 end

--- a/app/policies/specific_attribute_policy.rb
+++ b/app/policies/specific_attribute_policy.rb
@@ -1,10 +1,10 @@
 class SpecificAttributePolicy < ApplicationPolicy
   def index?
-    user_in_admin_group?
+    is_admin?
   end
 
   def create?
-    user_in_admin_group?
+    is_admin?
   end
 
   def new?
@@ -12,7 +12,7 @@ class SpecificAttributePolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_admin_group?
+    is_admin?
   end
 
   def edit?
@@ -20,6 +20,6 @@ class SpecificAttributePolicy < ApplicationPolicy
   end
 
   def destroy?
-    user_in_admin_group?
+    is_admin?
   end
 end

--- a/app/policies/static_page_policy.rb
+++ b/app/policies/static_page_policy.rb
@@ -5,7 +5,7 @@ class StaticPagePolicy < ApplicationPolicy
   end
 
   def dashboard?
-    user_in_admin_group?
+    is_admin?
   end
 
   def welcome_rovers?

--- a/app/policies/zone/building_policy.rb
+++ b/app/policies/zone/building_policy.rb
@@ -1,11 +1,11 @@
 class Zone::BuildingPolicy < ApplicationPolicy
 
   def create?
-    user_in_admin_group?
+    is_admin?
   end
 
   def update?
-    user_in_admin_group?
+    is_admin?
   end
   
   def edit?
@@ -13,6 +13,6 @@ class Zone::BuildingPolicy < ApplicationPolicy
   end
 
   def remove_building?
-    user_in_admin_group?
+    is_admin?
   end
 end

--- a/app/policies/zone_policy.rb
+++ b/app/policies/zone_policy.rb
@@ -1,14 +1,14 @@
 class ZonePolicy < ApplicationPolicy
   def index?
-    user_in_admin_group?
+    is_admin?
   end
 
   def show?
-    user_in_admin_group?
+    is_admin?
   end
 
   def create?
-    user_in_admin_group?
+    is_admin?
   end
 
   def new?
@@ -16,7 +16,7 @@ class ZonePolicy < ApplicationPolicy
   end
 
   def update?
-    user_in_admin_group?
+    is_admin?
   end
 
   def edit?
@@ -24,6 +24,6 @@ class ZonePolicy < ApplicationPolicy
   end
 
   def destroy?
-    user_in_admin_group?
+    is_admin?
   end
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,7 +11,7 @@
       <% end %>
 
       <% if user_signed_in? %>
-        <% if is_admin?(current_user) %>
+        <% if is_admin? %>
           <div class="nav-item dropdown navbar_dropdown_item h-100 px-2 rounded-0 border-0">
             <a class="nav-link h-100 d-flex align-items-center fs-5" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               Base

--- a/app/views/static_pages/dashboard.html.erb
+++ b/app/views/static_pages/dashboard.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-md-8 col-lg-6 w-100">
       <!-- Heading -->
-      <h1 class="text-start mt-6 ms-6">Room Ready Application</h1>
+      <h1 class="text-start mt-6 ms-6">Admin Dashboard</h1>
       <p class="mt-2 w-75">
        Dashboard
     </p>

--- a/spec/policies/app_preference_policy_spec.rb
+++ b/spec/policies/app_preference_policy_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe AppPreferencePolicy do
+  let(:user) { FactoryBot.create(:user) }
+  let(:app_preference) { AppPreference.new }
+
+  context 'with rover role' do
+    subject { described_class.new({ user: user, role: "rover" }, app_preference) }
+
+    it { is_expected.to permit_only_actions(%i[is_rover]) }
+  end
+
+  context 'with admin role' do
+    subject { described_class.new({ user: user, role: "admin" }, app_preference) }
+
+    it { is_expected.to permit_only_actions(%i[configure_prefs save_configured_prefs is_admin]) }
+  end
+
+  context 'with developer role' do
+    subject { described_class.new({ user: user, role: "developer" }, app_preference) }
+
+    it { is_expected.to forbid_action(:is_rover) }
+  end
+
+  context 'with no role' do
+    subject { described_class.new({ user: user, role: "none" }, app_preference) }
+
+    it { is_expected.to forbid_all_actions }
+  end
+
+end

--- a/spec/policies/building_policy_spec.rb
+++ b/spec/policies/building_policy_spec.rb
@@ -1,26 +1,29 @@
 require 'rails_helper'
 
 RSpec.describe BuildingPolicy do
-  subject { described_class.new(user, building) }
-
+  let(:user) { FactoryBot.create(:user) }
   let(:building) { Building.new }
 
   context 'with rovers' do
-    let(:rover) { FactoryBot.create(:rover) }
-    let(:user) { FactoryBot.create(:user, uniqname: rover.uniqname) }
+    subject { described_class.new({ user: user, role: "rover" }, building) }
 
-    it { is_expected.to permit_only_actions(%i[index show]) }
+    it { is_expected.to permit_only_actions(%i[index show is_rover]) }
   end
 
   context 'with admins' do
-    let(:user) { FactoryBot.create(:user, admin: true, membership: ['lsa-roomready-admins']) }
+    subject { described_class.new({ user: user, role: "admin" }, building) }
 
-    # it { is_expected.to permit_all_actions }
+    it { is_expected.to forbid_action(:is_rover) }
+  end
+
+  context 'with admins' do
+    subject { described_class.new({ user: user, role: "developer" }, building) }
+
     it { is_expected.to forbid_action(:is_rover) }
   end
 
   context 'with rovers' do
-    let(:user) { FactoryBot.create(:user) }
+    subject { described_class.new({ user: user, role: "none" }, building) }
 
     it { is_expected.to forbid_all_actions }
   end

--- a/spec/policies/building_policy_spec.rb
+++ b/spec/policies/building_policy_spec.rb
@@ -4,25 +4,25 @@ RSpec.describe BuildingPolicy do
   let(:user) { FactoryBot.create(:user) }
   let(:building) { Building.new }
 
-  context 'with rovers' do
+  context 'with rover role' do
     subject { described_class.new({ user: user, role: "rover" }, building) }
 
     it { is_expected.to permit_only_actions(%i[index show is_rover]) }
   end
 
-  context 'with admins' do
+  context 'with admin role' do
     subject { described_class.new({ user: user, role: "admin" }, building) }
 
-    it { is_expected.to forbid_action(:is_rover) }
+    it { is_expected.to forbid_actions(%i[is_rover is_developer]) }
   end
 
-  context 'with admins' do
+  context 'with developer role' do
     subject { described_class.new({ user: user, role: "developer" }, building) }
 
     it { is_expected.to forbid_action(:is_rover) }
   end
 
-  context 'with rovers' do
+  context 'with no role' do
     subject { described_class.new({ user: user, role: "none" }, building) }
 
     it { is_expected.to forbid_all_actions }

--- a/spec/policies/common_attribute_policy_spec.rb
+++ b/spec/policies/common_attribute_policy_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe CommonAttributePolicy do
+  let(:user) { FactoryBot.create(:user) }
+  let(:common_attribute) { CommonAttribute.new }
+
+  context 'with rover role' do
+    subject { described_class.new({ user: user, role: "rover" }, common_attribute) }
+
+    it { is_expected.to permit_only_actions(%i[is_rover]) }
+  end
+
+  context 'with admin role' do
+    subject { described_class.new({ user: user, role: "admin" }, common_attribute) }
+
+    it { is_expected.to forbid_actions(%i[is_rover is_developer]) }
+  end
+
+  context 'with developer role' do
+    subject { described_class.new({ user: user, role: "developer" }, common_attribute) }
+
+    it { is_expected.to forbid_action(:is_rover) }
+  end
+
+  context 'with no role' do
+    subject { described_class.new({ user: user, role: "none" }, common_attribute) }
+
+    it { is_expected.to forbid_all_actions }
+  end
+
+end

--- a/spec/policies/room_policy_spec.rb
+++ b/spec/policies/room_policy_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe RoomPolicy do
+  let(:user) { FactoryBot.create(:user) }
+  let(:room) { Room.new }
+
+  context 'with rover role' do
+    subject { described_class.new({ user: user, role: "rover" }, room) }
+
+    it { is_expected.to permit_only_actions(%i[is_rover]) }
+  end
+
+  context 'with admin role' do
+    subject { described_class.new({ user: user, role: "admin" }, room) }
+
+    it { is_expected.to forbid_actions(%i[is_rover is_developer]) }
+  end
+
+  context 'with developer role' do
+    subject { described_class.new({ user: user, role: "developer" }, room) }
+
+    it { is_expected.to forbid_action(:is_rover) }
+  end
+
+  context 'with no role' do
+    subject { described_class.new({ user: user, role: "none" }, room) }
+
+    it { is_expected.to forbid_all_actions }
+  end
+
+end

--- a/spec/policies/rover_policy_spec.rb
+++ b/spec/policies/rover_policy_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe RoverPolicy do
+  let(:user) { FactoryBot.create(:user) }
+  let(:rover) { Rover.new }
+
+  context 'with rover role' do
+    subject { described_class.new({ user: user, role: "rover" }, rover) }
+
+    it { is_expected.to permit_only_actions(%i[is_rover]) }
+  end
+
+  context 'with admin role' do
+    subject { described_class.new({ user: user, role: "admin" }, rover) }
+
+    it { is_expected.to forbid_actions(%i[is_rover is_developer]) }
+  end
+
+  context 'with developer role' do
+    subject { described_class.new({ user: user, role: "developer" }, rover) }
+
+    it { is_expected.to forbid_action(:is_rover) }
+  end
+
+  context 'with no role' do
+    subject { described_class.new({ user: user, role: "none" }, rover) }
+
+    it { is_expected.to forbid_all_actions }
+  end
+
+end

--- a/spec/policies/zone_policy_spec.rb
+++ b/spec/policies/zone_policy_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ZonePolicy do
+  let(:user) { FactoryBot.create(:user) }
+  let(:zone) { Zone.new }
+
+  context 'with rover role' do
+    subject { described_class.new({ user: user, role: "rover" }, zone) }
+
+    it { is_expected.to permit_only_actions(%i[is_rover]) }
+  end
+
+  context 'with admin role' do
+    subject { described_class.new({ user: user, role: "admin" }, zone) }
+
+    it { is_expected.to forbid_actions(%i[is_rover is_developer]) }
+  end
+
+  context 'with developer role' do
+    subject { described_class.new({ user: user, role: "developer" }, zone) }
+
+    it { is_expected.to forbid_action(:is_rover) }
+  end
+
+  context 'with no role' do
+    subject { described_class.new({ user: user, role: "none" }, zone) }
+
+    it { is_expected.to forbid_all_actions }
+  end
+
+end


### PR DESCRIPTION
The pull request has a refactored authorization process.

- set_user method in Users::OmniauthCallbacksController creates session[:role] (developer, admin, rover or none) depending on group membership (lsa-roomready-developers or lsa-roomready-admins) or a record exixtence in the rovers table
- application_helper's is_admin? and is_rover? methods return true or false depending on session[:role] value
- ApplicationController defines pundit_user as a hash `{ user: current_user, role: session[:role] }`
- application_policy.rb initializer receives 'context' and 'record' arguments, where context is the pundit_user hash
  - therefore role value is available to use in policies


The User model doesn't need virtual attributes anymore.
No need to call set_membership before_action in controllers.

Also, the pull request has refactored the rspec policies tests for some controllers (the controllers that use the 'authorize' statements and policy files)
 
 