### PR TITLE
Lra 928 room ready write rspec tests for rovers controller

### DIFF
--- a/app/controllers/rovers_controller.rb
+++ b/app/controllers/rovers_controller.rb
@@ -53,7 +53,7 @@ class RoversController < ApplicationController
   def update
     respond_to do |format|
       if @rover.update(rover_params)
-        format.html { redirect_to rover_url(@rover), notice: "Rover was successfully updated." }
+        format.html { redirect_to rovers_url, notice: "Rover was successfully updated." }
         format.json { render :show, status: :ok, location: @rover }
       else
         format.html { render :edit, status: :unprocessable_entity }
@@ -64,11 +64,13 @@ class RoversController < ApplicationController
 
   # DELETE /rovers/1 or /rovers/1.json
   def destroy
-    @rover.destroy!
-
-    respond_to do |format|
-      format.html { redirect_to rovers_url, notice: "Rover was successfully deleted." }
-      format.json { head :no_content }
+    if @rover.destroy
+      @rovers = Rover.all
+      @rover = Rover.new
+      flash.now[:notice] = "Rover was successfully deleted."
+    else
+      @rovers = Rover.all
+      flash.now[:notice] = "Error deleting rover."
     end
   end
 

--- a/app/views/rovers/_form.html.erb
+++ b/app/views/rovers/_form.html.erb
@@ -12,8 +12,10 @@
     <% end %>
     <div>
       <%= form.label :uniqname, "Create Rover by Uniqname:", style: "display: block" %>
-      <%= form.text_field :uniqname %>
-      <%= form.submit %>
+      <div class="d-flex flex-row justify-content-start align-items-center gap-3">
+        <%= form.text_field :uniqname, placeholder: "Uniqname", class: "w-50" %>
+        <%= form.submit "Create" %>
+      </div>
     </div>
   <% end %>
 <% end %>

--- a/app/views/rovers/destroy.turbo_stream.erb
+++ b/app/views/rovers/destroy.turbo_stream.erb
@@ -1,0 +1,9 @@
+<%= render_flash_stream %>
+
+<%= turbo_stream.update "new_rover" do %>
+  <%= render "form", rover: @rover %>
+<% end %>
+
+<%= turbo_stream.update "rovers" do %>
+  <%= render "listing" %>
+<% end %>

--- a/app/views/rovers/edit.html.erb
+++ b/app/views/rovers/edit.html.erb
@@ -1,5 +1,5 @@
 <p></p>
-<h1>Editing rover</h1>
+<h1>Editing Rover</h1>
 
 <%= form_with(model: rover=@rover) do |form| %>
   <% if rover.errors.any? %>
@@ -25,7 +25,7 @@
     <%= form.text_field :last_name %>
   </div>
   <div>
-    <%= form.submit %>
+    <%= form.submit "Update" %>
   </div>
 <% end %>
 <br>

--- a/app/views/rovers/index.html.erb
+++ b/app/views/rovers/index.html.erb
@@ -2,12 +2,17 @@
 <h1>Rover List</h1>
 <div id="search bar">
   <%= form_with url: rovers_path, method: :get, local: true do |form| %>
-    <%= form.label :search, "Search Rovers by Name or Uniqname:", style: "display: block" %>
-    <%= form.text_field :search, value: params[:search] %>
+    <%= form.label :search, class: "invisible" %>
+    <div class="d-flex flex-row justify-content-start align-items-center gap-3">
+    <%= form.text_field :search, value: params[:search], placeholder: "Search by Name or Uniqname", class: "w-50" %>
     <%= form.submit "Search" %>
+    </div>
   <% end %>
 </div>
 
-<%= render "form", rover: @rover %>
-<br>
-<%= render "listing" %>
+<div>
+  <%= render "form", rover: @rover %>
+</div>
+<div class="mt-2">
+  <%= render "listing" %>
+</div>

--- a/spec/system/rover_controller_spec.rb
+++ b/spec/system/rover_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rover, type: :system do
     mock_login(user)
   end
 
-	context 'create a new rover with invalid uniqname' do
+  context 'create a new rover with invalid uniqname' do
     it 'returns "uniqname is invalid" message' do
       VCR.use_cassette "building" do
         uniqname = 'randomname'

--- a/spec/system/rover_controller_spec.rb
+++ b/spec/system/rover_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Rover, type: :system do
   end
 
   context 'fail deleting a rover' do
-    let!(:rover) { build_stubbed(:rover) }
+    let!(:rover) { create(:rover) }
 
     it 'click on delete icon and delete returns error' do
       allow(rover).to receive(:destroy).and_return(false)

--- a/spec/system/rover_controller_spec.rb
+++ b/spec/system/rover_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Rover, type: :system do
 
   before do
-		user = FactoryBot.create(:user)
+    user = FactoryBot.create(:user)
     allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-developers').and_return(false)
     allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-admins').and_return(true)
     mock_login(user)

--- a/spec/system/rover_controller_spec.rb
+++ b/spec/system/rover_controller_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Rover, type: :system do
     end
   end
 
-	context 'edit a rover' do
+  context 'edit a rover' do
     let!(:rover) { FactoryBot.create(:rover) }
     it 'go to Editing Rover page' do
       VCR.use_cassette "rover" do

--- a/spec/system/rover_controller_spec.rb
+++ b/spec/system/rover_controller_spec.rb
@@ -1,0 +1,90 @@
+require 'rails_helper'
+
+RSpec.describe Rover, type: :system do
+
+  before do
+		user = FactoryBot.create(:user)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-developers').and_return(false)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-admins').and_return(true)
+    mock_login(user)
+  end
+
+	context 'create a new rover with invalid uniqname' do
+    it 'returns "uniqname is invalid" message' do
+      VCR.use_cassette "building" do
+        uniqname = 'randomname'
+        result = {"valid"=>false, "note"=>"The 'randomname' uniqname is not valid.", "last_name"=>"", "first_name"=>"", "name"=>""}
+        allow_any_instance_of(RoversController).to receive(:get_rover_info).with(uniqname).and_return(result)
+        visit rovers_path
+        fill_in "Create Rover by Uniqname", with: uniqname
+        click_on "Create"
+        expect(page).to have_content("is not valid.")
+      end
+    end
+  end
+
+  context 'create a new rover with valid uniqname' do
+    it 'returns "Rover was successfully created" message' do
+      VCR.use_cassette "rover" do
+        uniqname = 'qwerty'
+        result = {"valid"=>true, "note"=>"Uniqname is valid", "last_name"=>"Lastname", "first_name"=>"Firstname", "name"=>"Firstname Lastname"}
+        allow_any_instance_of(RoversController).to receive(:get_rover_info).with(uniqname).and_return(result)
+        visit rovers_path
+        fill_in "Create Rover by Uniqname", with: uniqname
+        click_on "Create"
+        expect(page).to have_content("Rover was successfully created.")
+      end
+    end
+  end
+
+	context 'edit a rover' do
+    let!(:rover) { FactoryBot.create(:rover) }
+    it 'go to Editing Rover page' do
+      VCR.use_cassette "rover" do
+        visit rovers_path
+        find(:css, 'i.bi.bi-pencil-square.text-primary').click
+        expect(page).to have_content("Editing Rover")
+      end
+    end
+  end
+
+  context 'delete a rover' do
+    let!(:rover) { FactoryBot.create(:rover) }
+    it 'click on delete icon and cancel deleting' do
+      VCR.use_cassette "rover" do
+        visit rovers_path
+        dismiss_confirm 'Are you sure you want to delete this rover?' do
+          find(:css, 'i.bi.bi-trash-fill.text-danger').click
+        end
+        expect(page).to_not have_content("Rover was successfully deleted.")
+      end
+    end
+
+    it 'click on delete icon and update first name' do
+      VCR.use_cassette "rover" do
+        visit rovers_path
+        accept_confirm 'Are you sure you want to delete this rover?' do
+          find(:css, 'i.bi.bi-trash-fill.text-danger').click
+        end
+        expect(page).to have_content("Rover was successfully deleted.")
+      end
+    end
+  end
+
+  context 'fail deleting a rover' do
+    let!(:rover) { build_stubbed(:rover) }
+
+    it 'click on delete icon and delete returns error' do
+      allow(rover).to receive(:destroy).and_return(false)
+      allow(Rover).to receive(:find).and_return(rover)
+      VCR.use_cassette "rover" do
+        visit rovers_path
+        accept_confirm 'Are you sure you want to delete this rover?' do
+          find(:css, 'i.bi.bi-trash-fill.text-danger').click
+        end
+        expect(page).to have_content("Error deleting rover.")
+      end
+    end
+  end
+
+end

--- a/spec/system/rovers_user_is_not_authorized_spec.rb
+++ b/spec/system/rovers_user_is_not_authorized_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Rover, type: :system do
 		mock_login(user)
   end
 
-	context 'create a new rover' do
+  context 'create a new rover' do
     it 'returns a "You are not authorized to perform this action." message' do
       VCR.use_cassette "rover" do
         visit rovers_path

--- a/spec/system/rovers_user_is_not_authorized_spec.rb
+++ b/spec/system/rovers_user_is_not_authorized_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe Rover, type: :system do
+
+  before do
+		user = FactoryBot.create(:user)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-developers').and_return(false)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-admins').and_return(false)
+		mock_login(user)
+	end
+
+	context 'create a new rover' do
+    it 'returns a "You are not authorized to perform this action." message' do
+      VCR.use_cassette "rover" do
+        visit rovers_path
+        sleep 2
+        expect(page).to have_content("You are not authorized to perform this action.")
+      end
+    end
+  end
+
+  context 'edit a rover' do
+    let!(:rover) { FactoryBot.create(:rover) }
+
+    it 'returns a "You are not authorized to perform this action." message' do
+      VCR.use_cassette "rover" do
+        visit edit_rover_path(rover)
+        sleep 2
+        expect(page).to have_content("You are not authorized to perform this action.")
+      end
+    end
+  end
+  
+end

--- a/spec/system/rovers_user_is_not_authorized_spec.rb
+++ b/spec/system/rovers_user_is_not_authorized_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Rover, type: :system do
 
   before do
-		user = FactoryBot.create(:user)
+    user = FactoryBot.create(:user)
     allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-developers').and_return(false)
     allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-admins').and_return(false)
 		mock_login(user)
-	end
+  end
 
 	context 'create a new rover' do
     it 'returns a "You are not authorized to perform this action." message' do
@@ -21,7 +21,6 @@ RSpec.describe Rover, type: :system do
 
   context 'edit a rover' do
     let!(:rover) { FactoryBot.create(:rover) }
-
     it 'returns a "You are not authorized to perform this action." message' do
       VCR.use_cassette "rover" do
         visit edit_rover_path(rover)


### PR DESCRIPTION
While writing tests I edited the following in rovers pages (see the changed files):

- redirection after creating
- in destroy method, a failed check was added
- new rover form's format
- in Editing Rover Submit replaced with Update

Run tests with the following commands:

SHOW_BROWSER=true rspec spec/system/rover*
or
rspec spec/system/rover*

To run all system tests:
rspec spec/system/*