### PR TITLE
Lra 951 room ready GitHub action for automatically running tests

### DIFF
--- a/.github/workflows/run-rspec-tests.yml
+++ b/.github/workflows/run-rspec-tests.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   run-rspec-tests:
     runs-on: ubuntu-latest
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432
     services:
       postgres:
         image: postgres
@@ -21,6 +24,7 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=3
+
     steps:
       - uses: actions/checkout@v4
 
@@ -32,38 +36,30 @@ jobs:
 
       - name: Set up PostgreSQL client
         run: sudo apt-get install -y postgresql-client
+
       - name: Install Node.js
         with:
           node-version-file: '.node-version'
         uses: actions/setup-node@v3
+
       - name: Install Yarn
         run: npm install -g yarn
+
       - name: Install Dependencies
         run: |
           bundle install
           yarn install
 
       - name: Precompile Assets
-        env:
-          RAILS_ENV: test
         run: bundle exec rails assets:precompile
 
       - name: Setup DB
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
         run: bin/rails db:create db:migrate db:seed
 
       - name: Run Model tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
         run: bundle exec rspec spec/models/*
 
       - name: Run System tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432
         run: bundle exec rspec spec/system/*
 
       - name: Keep screenshots from failed system tests

--- a/.github/workflows/run-rspec-tests.yml
+++ b/.github/workflows/run-rspec-tests.yml
@@ -1,0 +1,75 @@
+name: Run RSpec tests
+
+on:
+  push:
+    branches:
+      - staging
+
+jobs:
+  run-rspec-tests:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with: # gets version from .ruby-version file
+          # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
+
+      - name: Set up PostgreSQL client
+        run: sudo apt-get install -y postgresql-client
+      - name: Install Node.js
+        with:
+          node-version-file: '.node-version'
+        uses: actions/setup-node@v3
+      - name: Install Yarn
+        run: npm install -g yarn
+      - name: Install Dependencies
+        run: |
+          bundle install
+          yarn install
+
+      - name: Precompile Assets
+        env:
+          RAILS_ENV: test
+        run: bundle exec rails assets:precompile
+
+      - name: Setup DB
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+        run: bin/rails db:create db:migrate db:seed
+
+      - name: Run Model tests
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+        run: bundle exec rspec spec/models/*
+
+      - name: Run System tests
+        env:
+          RAILS_ENV: test
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432
+        run: bundle exec rspec spec/system/*
+
+      - name: Keep screenshots from failed system tests
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: screenshots
+          path: ${{ github.workspace }}/tmp/capybara
+          if-no-files-found: ignore

--- a/spec/policies/building_policy_spec.rb
+++ b/spec/policies/building_policy_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe BuildingPolicy, type: :policy do
   context 'with rover role' do
     subject { described_class.new({ user: user, role: "rover" }, building) }
 
-    it { is_expected.to permit_only_actions(%i[index show is_rover]) }
+    it { is_expected.to permit_only_actions(%i[is_rover]) }
   end
 
   context 'with admin role' do

--- a/spec/system/building_controller_spec.rb
+++ b/spec/system/building_controller_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe Building, type: :system do
           "BuildingTypeDescription"=>"Teach, Research, Support", "BuildingPhaseCode"=>"SERV", "BuildingPhaseDescription"=>"In Service", 
           "BuildingCampusCode"=>"100", "BuildingCampusDescription"=>"Central Campus", "BuildingOwnership"=>"Owned"}]}
         allow_any_instance_of(BuildingApi).to receive(:get_building_info_by_bldrecnbr).with(bldrecnbr).and_return(result)
+        allow_any_instance_of(BuildingApi).to receive(:get_classrooms_for_building).with(bldrecnbr).and_return({})
         visit new_building_path
         fill_in "Building Record Number", with: "1234567"
         click_on "Create Building"


### PR DESCRIPTION
Adds a Github Action to run rspec tests when pushing/merging to staging branch. Runs:
- `spec/models`
- `spec/policies`
- `spec/system`


See https://github.com/Mohammad4844/room_ready_test/actions
- this is a clone repo I made on my account
- check the latest github action run. its an example of how it would run here

Note 1: Also uploads artifacts/screenshots from capybara when a test fails (if they are saved). 
- See the github action's log for a link to the artifacts. 
-  See the last thing 'Keep screenshots from failed system tests' in the github action yaml file.
- The default retention period for logs & artifacts is [90 days](https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts#about-workflow-artifacts).

Note 2: Github actions is free for public repositories, so there is no cost to this. See [this](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates).

