### PR TITLE
fix issue with resource state validation

### DIFF
--- a/app/models/resource_state.rb
+++ b/app/models/resource_state.rb
@@ -13,5 +13,6 @@ class ResourceState < ApplicationRecord
   belongs_to :room_state
   belongs_to :resource
 
-  validates :is_checked, presence: true
+  validates :is_checked, inclusion: { in: [true, false], message: 'must be a present (either true or false)' }
+
 end

--- a/spec/models/resource_state_spec.rb
+++ b/spec/models/resource_state_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe ResourceState, type: :model do
   end
 
   context "create resource_state without an is_checked value" do
-    it 'raise error "ActiveRecord::RecordInvalid: Validation failed: Is checked can\'t be blank"' do
-      expect { FactoryBot.create(:resource_state, is_checked: nil) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Is checked can't be blank")
+    it 'raise error "ActiveRecord::RecordInvalid: Validation failed: Is checked must be a present (either true or false)"' do
+      expect { FactoryBot.create(:resource_state, is_checked: nil) }.to raise_error(ActiveRecord::RecordInvalid, "Validation failed: Is checked must be a present (either true or false)")
     end
   end
 end


### PR DESCRIPTION
Fixed an issue with one of the validations i added for resource state. Specifically `validates :is_checked, presence: true`, which makes it so `false` values are also not allowed. 