### PR TITLE
Lra 933 room ready refactor update states methods

### DIFF
--- a/app/models/zone.rb
+++ b/app/models/zone.rb
@@ -10,15 +10,7 @@
 class Zone < ApplicationRecord
   validates :name, uniqueness: true
   validates :name, presence: true
-  has_many :buildings
-
-  def rooms_checked_today
-    Room.joins(floor: { building: :zone })
-        .includes(:room_states)
-        .where(zones: { id: self.id })
-        .select { |room| RoomStatus.new(room).room_checked_today? && RoomStatus.new(room).calculate_percentage.to_f == 100.0 }
-        .count
-  end
+  has_many :buildings, -> { active }, class_name: 'Building'
 
   def total_rooms
     Room.joins(floor: { building: :zone })

--- a/app/views/rooms/room_states/_form.html.erb
+++ b/app/views/rooms/room_states/_form.html.erb
@@ -31,7 +31,11 @@
   </div>
 
   <div>
-    <%= form.submit "Create Room State" %>
+    <% if action_name == "new" %>
+      <%= form.submit "Create Room State" %>
+    <% else %>
+      <%= form.submit "Update Room State" %>
+    <% end %>
     <%= link_to "Cancel", :back, class:"link_to" %>
   </div>
 

--- a/app/views/rooms/room_states/_form.html.erb
+++ b/app/views/rooms/room_states/_form.html.erb
@@ -31,7 +31,7 @@
   </div>
 
   <div>
-    <%= form.submit %>
+    <%= form.submit "Create Room State" %>
     <%= link_to "Cancel", :back, class:"link_to" %>
   </div>
 

--- a/app/views/rover_navigations/zones.html.erb
+++ b/app/views/rover_navigations/zones.html.erb
@@ -13,7 +13,7 @@
               zone.buildings.order(:name).pluck(:name).join(', '),
               length: 60, omission: '...') %>
       </p>
-      <%= link_to "Zone Details", buildings_rover_navigation_path(zone_id: zone.id), class: "btn btn-primary" %>
+      <%= link_to "#{zone.name} Details", buildings_rover_navigation_path(zone_id: zone.id), class: "btn btn-primary" %>
     </div>
   </div>
 <% end %>

--- a/spec/support/test_seeds.rb
+++ b/spec/support/test_seeds.rb
@@ -1,0 +1,35 @@
+# This file should ensure the existence of records required to run the application in every environment (production,
+# development, test). The code here should be idempotent so that it can be executed at any point in every environment.
+# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
+#
+# Example:
+#
+#   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
+#     MovieGenre.find_or_create_by!(name: genre_name)
+#   end
+
+locations = ['about_page', 'rovers_form', 'preference_page', 'rovers_welcome_page', 'common_form', 'specific_form', 'resource_form'] #hardcoded locations
+existing_locations = Announcement.all.pluck(:location)
+locations.each do |location|
+  unless existing_locations.include?(location)
+    Announcement.create!(location: location)
+  end
+end
+
+preferences = [
+  {:name => 'no_access_reason', :description => "Comma-separated list of why you can't access a room", :pref_type => 'string'},
+  {:name => 'supervisor_phone_number', :description => 'A phone to report to a supervisor', :pref_type => 'string'},
+  {:name => 'resource_types', :description => 'Comma-separated list of resource types to add from WebCheckout', :pref_type => 'string'},
+  {:name => 'tdx_lsa_ts_email', :description => 'An email address to create a TDX ticket with LSA TS', :pref_type => 'string', :value => "Technology Issues (all classrooms): LSATechnologyServices@umich.edu"},
+  {:name => 'tdx_facilities_email', :description => 'An email address to create a TDX ticket with LSA Facilities', :pref_type => 'string', :value => "Facilities Issues (LSA classrooms): lsa-facilities@umich.edu"},
+  {:name => 'dana_building_facility_issues_email', :description => 'An email address to report Dana Building Facility Issues', :pref_type => 'string', :value => "Dana Building Facility Issues: seas-facilities@umich.edu"},
+  {:name => 'skb_facility_issues_email', :description => 'An email address to report SKB Building Facility Issues', :pref_type => 'string', :value => "SKB Facility Issues: ptitus@umich.edu"},
+  {:name => 'tdx_tickets_quantity_on_dashboard', :description => 'How many recent Room Issues should be displayed on the Dashboard?', :pref_type => 'integer', :value => 6}
+]
+existing_preferences = AppPreference.all.pluck(:name)
+
+preferences.each do |pref|
+  unless existing_preferences.include?(pref[:name])
+    AppPreference.create!(pref)
+  end
+end

--- a/spec/system/common_attributes_state_controller_spec.rb
+++ b/spec/system/common_attributes_state_controller_spec.rb
@@ -29,4 +29,26 @@ RSpec.describe CommonAttributeState, type: :system do
     end
   end
   
+  context 'edit a common attribute state' do
+    let!(:room) { FactoryBot.create(:room) }
+    let!(:common_attribute1) { FactoryBot.create(:common_attribute) }
+    let!(:common_attribute2) { FactoryBot.create(:common_attribute) }
+    let!(:room_state) { FactoryBot.create(:room_state, room: room) }
+    let!(:common_attribute_state1) { FactoryBot.create(:common_attribute_state, room_state: room_state, common_attribute: common_attribute1) }
+    let!(:common_attribute_state2) { FactoryBot.create(:common_attribute_state, room_state: room_state, common_attribute: common_attribute2) }
+    let!(:common_attribute2) { FactoryBot.create(:common_attribute) }
+
+    it 'fills out the form and submits it' do
+      VCR.use_cassette "common_attribute_state" do
+        visit "rooms/#{room.id}/room_states/#{room_state.id}/edit"
+        click_on "Update Room State"
+        expect(page).to have_content("Editing Common Room Questions")
+        find('label[for=common_attribute_states_0_checkbox_value_true]').click
+        find('label[for=common_attribute_states_1_checkbox_value_true]').click
+        click_on "Update Response"
+        expect(page).to have_content("Room Check Confirmation")
+      end
+    end
+  end
+
 end

--- a/spec/system/common_attributes_state_controller_spec.rb
+++ b/spec/system/common_attributes_state_controller_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe CommonAttributeState, type: :system do
+
+  before do
+    load "#{Rails.root}/spec/support/test_seeds.rb" 
+		user = FactoryBot.create(:user)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-developers').and_return(false)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-admins').and_return(true)
+    mock_login(user)
+	end
+
+	context 'create a new common attribute state' do
+    let!(:room) { FactoryBot.create(:room) }
+    let!(:common_attribute1) { FactoryBot.create(:common_attribute) }
+    let!(:common_attribute2) { FactoryBot.create(:common_attribute) }
+
+    it 'fills out the form and submits it' do
+      VCR.use_cassette "common_attribute_state" do
+        visit "rooms/#{room.id}/room_states/new"
+        find(:label, 'Yes').click
+        click_on "Create Room State"
+        expect(page).to have_content("Common Room Questions")
+        find('label[for=common_attribute_states_0_checkbox_value_true]').click
+        find('label[for=common_attribute_states_1_checkbox_value_true]').click
+        click_on "Save Response"
+        expect(page).to have_content("Room Check Confirmation")
+      end
+    end
+  end
+  
+end

--- a/spec/system/shib_login_spec.rb
+++ b/spec/system/shib_login_spec.rb
@@ -2,20 +2,29 @@ require 'rails_helper'
 
 RSpec.describe "Controllers", type: :request do
 
+  before do
+    allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-developers').and_return(true)
+    allow(LdapLookup).to receive(:is_member_of_group?).with(anything, 'lsa-roomready-admins').and_return(false)
+  end
+
   describe 'login success' do
     it 'displays welcome message on programs page' do
-      user = FactoryBot.create(:user)
-      mock_login(user)
-      follow_redirect!
-      expect(response.body).to include("Signed in successfully.")
+      VCR.use_cassette "login" do
+        user = FactoryBot.create(:user)
+        mock_login(user)
+        follow_redirect!
+        expect(response.body).to include("Signed in successfully.")
+      end
     end
   end
 
   describe 'login failure' do
     it 'displays welcome message on programs page' do
-      user = FactoryBot.build(:user, email: "wrongemial")
-      mock_login(user)
-      expect(response.body).not_to include("Welcome")
+      VCR.use_cassette "login" do
+        user = FactoryBot.build(:user, email: "wrongemial")
+        mock_login(user)
+        expect(response.body).not_to include("Welcome")
+      end
     end
   end
 


### PR DESCRIPTION
Refactor update_...item..._states methods in states controllers.

Added a test for the CommonAttributeState controller.
Writing test noticed and fixed/edited the following:

- noticed that zones display all buildings (including archived) in rover form - added a 'scope' to zones

`has_many :buildings, -> { active }, class_name: 'Building'` - zones don't need to know about archived buildings

- edit a submit button text for room_state forms
- added zones and rooms names to rover forms buttons
- added test_seed file to spec directory
- edited spec/system/shib_login_spec.rb test to run without network