### PR TITLE
Lra 954 room ready delete and archive rooms

### DIFF
--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -111,6 +111,7 @@ class BuildingsController < ApplicationController
       @building.update(zone_id: nil)
     end
     if @building.update(archived: true)
+      change_rooms_archived_mode(@building, true)
       @buildings = Building.active.order(:name)
       redirect_back_or_default(notice: "The building was archived")
     else
@@ -123,6 +124,7 @@ class BuildingsController < ApplicationController
     authorize @building
     @archived = true
     if @building.update(archived: false)
+      change_rooms_archived_mode(@building, false)
       @buildings = Building.archived.order(:name)
       redirect_back_or_default(notice: "The building was unarchived")
     else
@@ -135,6 +137,7 @@ class BuildingsController < ApplicationController
     authorize @building
     @archived = true
     if @building.update(archived: false)
+      change_rooms_archived_mode(@building, false)
       @buildings = Building.archived.order(:name)
       @zones = Zone.all.order(:name).map { |z| [z.name, z.id] }
       @zones << ["No Zone", 0]
@@ -215,6 +218,10 @@ class BuildingsController < ApplicationController
       else
         note = " API returned bo data about classrooms for the building"
       end
+    end
+
+    def change_rooms_archived_mode(building, archived_mode)
+      Room.where(floor_id: building.floors.ids).update_all(archived: archived_mode)
     end
 
     def delete_building(building)

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -46,27 +46,11 @@ class BuildingsController < ApplicationController
   end
 
   def show
-    floors_archived  = []
-    floors_active  = []
-    
-    @building.floors.each do |floor|
-      if floor.archived_rooms.present?
-        floors_archived << floor
-      end
-      if floor.active_rooms.present?
-        floors_active << floor
-      end
-    end
-    
-    if params["show_archived_rooms"] == "1"
-      floors = floors_archived
-      @archived = true
-    else
-      @archived = false
-      floors = floors_active
-    end
+    # to show/hide 'Show Archived Rooms' checkbox and show active or archived rooms on floors on Buiding show page
+    @archived = params["show_archived_rooms"] == "1" ? true : false 
 
     authorize @building
+    floors = @building.floors
     floor_names_sorted = sort_floors(floors.pluck(:name).uniq)
     @floors = floors.in_order_of(:name, floor_names_sorted)
   end

--- a/app/controllers/buildings_controller.rb
+++ b/app/controllers/buildings_controller.rb
@@ -41,8 +41,27 @@ class BuildingsController < ApplicationController
   end
 
   def show
+    floors_archived  = []
+    floors_active  = []
+    
+    @building.floors.each do |floor|
+      if floor.archived_rooms.present?
+        floors_archived << floor
+      end
+      if floor.active_rooms.present?
+        floors_active << floor
+      end
+    end
+    
+    if params["show_archived_rooms"] == "1"
+      floors = floors_archived
+      @archived = true
+    else
+      @archived = false
+      floors = floors_active
+    end
+
     authorize @building
-    floors = @building.floors
     floor_names_sorted = sort_floors(floors.pluck(:name).uniq)
     @floors = floors.in_order_of(:name, floor_names_sorted)
   end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -70,7 +70,7 @@ class RoomsController < ApplicationController
   def archive
     session[:return_to] = request.referer
     if @room.update(archived: true)
-      @rooms = Room.active.order(:name)
+      # @rooms = Room.active.order(:name)
       redirect_back_or_default(notice: "The room was archived")
     else
       @rooms = Room.active.order(:name)
@@ -81,7 +81,7 @@ class RoomsController < ApplicationController
     session[:return_to] = request.referer
     @archived = true
     if @room.update(archived: false)
-      @rooms = Room.archived.order(:name)
+      # @rooms = Room.archived.order(:name)
       redirect_back_or_default(notice: "The room was unarchived")
     else
       @rooms = Room.archived.order(:name)

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -70,7 +70,6 @@ class RoomsController < ApplicationController
   def archive
     session[:return_to] = request.referer
     if @room.update(archived: true)
-      # @rooms = Room.active.order(:name)
       redirect_back_or_default(notice: "The room was archived")
     else
       @rooms = Room.active.order(:name)
@@ -81,7 +80,6 @@ class RoomsController < ApplicationController
     session[:return_to] = request.referer
     @archived = true
     if @room.update(archived: false)
-      # @rooms = Room.archived.order(:name)
       redirect_back_or_default(notice: "The room was unarchived")
     else
       @rooms = Room.archived.order(:name)

--- a/app/controllers/rover_navigations_controller.rb
+++ b/app/controllers/rover_navigations_controller.rb
@@ -20,7 +20,7 @@ class RoverNavigationsController < ApplicationController
   def rooms
     authorize :rover_navigation, :rooms?
     @floor = Floor.find(params[:floor_id])
-    @rooms = @floor.rooms.order(:room_number)
+    @rooms = @floor.active_rooms.order(:room_number)
 
     if params[:search].present?
       @rooms = @rooms.where("room_number ILIKE :search", search: "%#{params[:search]}%")

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -160,5 +160,14 @@ module ApplicationHelper
   def show_user_name_by_id(id)
     User.find(id).display_name
   end
+
+  def has_archived_rooms?(building)
+    building.floors.each do |floor|
+      if floor.archived_rooms.present?
+        return true
+      end
+    end
+    return false
+  end
   
 end

--- a/app/models/floor.rb
+++ b/app/models/floor.rb
@@ -11,6 +11,8 @@
 class Floor < ApplicationRecord
   belongs_to :building
   has_many :rooms
+  has_many :active_rooms, -> { active }, class_name: 'Room'
+  has_many :archived_rooms, -> { archived }, class_name: 'Room'
 
   validates :name, presence: true
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -29,7 +29,8 @@ class Room < ApplicationRecord
   scope :archived, -> { where(archived: true) }
 
   def full_name
-    [floor.building.nick_name, room_number].join(' ')
+    archived = self.archived ? " - archived" : ""
+    [floor.building.nick_name, room_number, archived].join(' ')
   end
 
   def room_state?

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -10,6 +10,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  last_time_checked :datetime
+#  archived          :boolean          default(FALSE)
 #
 class Room < ApplicationRecord
   belongs_to :floor
@@ -23,6 +24,9 @@ class Room < ApplicationRecord
   validates :room_number, :room_type, presence: true
 
   accepts_nested_attributes_for :specific_attributes
+
+  scope :active, -> { where(archived: false) }
+  scope :archived, -> { where(archived: true) }
 
   def full_name
     [floor.building.nick_name, room_number].join(' ')

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -18,4 +18,12 @@ class RoomPolicy < ApplicationPolicy
   def destroy?
     is_admin?
   end
+
+  def archive?
+    is_admin?
+  end
+
+  def unarchive?
+    is_admin?
+  end
 end

--- a/app/views/buildings/_building.html.erb
+++ b/app/views/buildings/_building.html.erb
@@ -29,16 +29,16 @@
 
 <div class="d-flex flex-row justify-content-start align-items-center gap-3 pl-2">
   <% unless building.has_checked_rooms? %>
-    <%= link_to building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Delete", data: { turbo_confirm: "Are you sure you want to delete this building?" , turbo_method: :delete } do %>
+    <%= link_to building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Delete", data: { turbo_confirm: "Are you sure you want to delete this building?", turbo_method: :delete } do %>
       <i class="bi bi-trash-fill text-danger"></i>
     <% end %>
   <% else %>
     <% if building.archived %>
-      <%= link_to unarchive_building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Unarchive", data: { turbo_confirm: "Are you sure you want to unarchive this building?" , turbo_method: :post }  do %>
+      <%= link_to unarchive_building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Unarchive", data: { turbo_confirm: "Are you sure you want to unarchive this building?", turbo_method: :post }  do %>
         <i class="bi bi-archive text-success"></i>
       <% end %>
       <% else %>
-      <%= link_to archive_building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Archive", data: { turbo_confirm: "Are you sure you want to archive this building?" , turbo_method: :post }  do %>
+      <%= link_to archive_building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Archive", data: { turbo_confirm: "Are you sure you want to archive this building?", turbo_method: :post }  do %>
         <i class="bi bi-archive-fill text-success"></i>
       <% end %>
     <% end %>

--- a/app/views/buildings/_building.html.erb
+++ b/app/views/buildings/_building.html.erb
@@ -32,15 +32,15 @@
     <%= link_to building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Delete", data: { turbo_confirm: "Are you sure you want to delete this building?" , turbo_method: :delete } do %>
       <i class="bi bi-trash-fill text-danger"></i>
     <% end %>
-  <% end %>
-
-  <% if building.archived %>
-    <%= link_to unarchive_building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Unarchive", data: { turbo_confirm: "Are you sure you want to unarchive this building?" , turbo_method: :post }  do %>
-      <i class="bi bi-archive text-success"></i>
-    <% end %>
-    <% else %>
-    <%= link_to archive_building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Archive", data: { turbo_confirm: "Are you sure you want to archive this building?" , turbo_method: :post }  do %>
-      <i class="bi bi-archive-fill text-success"></i>
+  <% else %>
+    <% if building.archived %>
+      <%= link_to unarchive_building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Unarchive", data: { turbo_confirm: "Are you sure you want to unarchive this building?" , turbo_method: :post }  do %>
+        <i class="bi bi-archive text-success"></i>
+      <% end %>
+      <% else %>
+      <%= link_to archive_building_path(building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Archive", data: { turbo_confirm: "Are you sure you want to archive this building?" , turbo_method: :post }  do %>
+        <i class="bi bi-archive-fill text-success"></i>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/buildings/_floors.html.erb
+++ b/app/views/buildings/_floors.html.erb
@@ -1,0 +1,56 @@
+<%= turbo_frame_tag 'all_floors' do %>  
+  <div class="accordion accordion-flush" id="buildingFloors">
+    <% @floors.each do |floor| %>
+      <div class="accordion-item">
+        <h2 class="accordion-header">
+          <button class="accordion-button collapsed bg-accordion" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_<%= floor.id %>" aria-expanded="false" aria-controls="collapse_<%= floor.id %>">
+            Floor <%= floor.name %> 
+          </button>
+        </h2>
+        
+        <div id="collapse_<%= floor.id %>" class="accordion-collapse collapse" data-bs-parent="#buildingFloors">
+          <div class="accordion-body">
+            <%= turbo_frame_tag 'all_rooms' do %>  
+              <table class="table text-center">
+                <thead class="table-group-divider">
+                  <tr>
+                    <th>Room Record Number</th>
+                    <th>Number</th>
+                    <th>Room Type</th>
+                    <td>View</td>
+                  </tr>
+                </thead>
+                <tbody class="table-group-divider">
+                  <% if @archived %>
+                    <% rooms = floor.archived_rooms %>
+                  <% else %>
+                    <% rooms = floor.active_rooms %>
+                  <% end %>
+                  <% rooms.order(:room_number).each do |room| %>
+                    <tr class="building_tbody_tr">
+                      <td class="building_tbody_td">
+                        <%#= link_to room.room_number, room_path(room), class: "link_to" %>
+                        <%= room.rmrecnbr %>
+                      </td>
+                      <td class="building_tbody_td">
+                        <%= link_to room.room_number, room_path(room), data: { turbo_frame: "_top" }, class: "link_to" %>
+                      </td>
+                      <td class="building_tbody_td">
+                      <%= room.room_type %>
+                    </td>
+                      <td class="building_tbody_td">
+                        <%= link_to room_path(room), class: "link_to", data: { turbo_frame: "_top" } do %>
+                        <i class="bi bi-eye-fill text-primary"></i>
+                        <% end %>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/buildings/_floors.html.erb
+++ b/app/views/buildings/_floors.html.erb
@@ -39,7 +39,7 @@
                       <%= room.room_type %>
                     </td>
                       <td class="building_tbody_td">
-                        <%= link_to room_path(room), class: "link_to", data: { turbo_frame: "_top" } do %>
+                        <%= link_to room_path(room), class: "link_to", 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "View", data: { turbo_frame: "_top" } do %>
                         <i class="bi bi-eye-fill text-primary"></i>
                         <% end %>
                       </td>

--- a/app/views/buildings/index.html.erb
+++ b/app/views/buildings/index.html.erb
@@ -20,10 +20,12 @@
         <label for="zone_id" aria-label="zone_id" style="display: inline;"></label>
         <%= form.select "zone_id", options_for_select(@zones, selected: params[:zone_id]), {include_blank: "Select Zone ..."}, { :"data-action" => "change->autosubmit#submitForm" } %>
       </div>
-      <div class="mt-2">
-        <%= form.check_box :show_archived, class: "form-check-input", data: { action: "input->autosubmit#search" }  %>
-        <%= form.label :show_archived, "Show Archived Buildings" %>
-      </div>
+      <% if Building.archived.present? %>
+        <div class="mt-2">
+          <%= form.check_box :show_archived, class: "form-check-input", data: { action: "input->autosubmit#search" }  %>
+          <%= form.label :show_archived, "Show Archived Buildings" %>
+        </div>
+      <% end %>
       <div class="mt-2">
         <a class="link_to" data-action="autosubmit#clearFilters">
           Clear Filters

--- a/app/views/buildings/show.html.erb
+++ b/app/views/buildings/show.html.erb
@@ -11,64 +11,25 @@
 </div>
 <%= render @building %>
 
+<% if has_archived_rooms?(@building) %>
+  <%= form_with url: building_path(@building), method: :get, class: "", 
+        data: { 
+          controller: "autosubmit", 
+          autosubmit_target: "form", 
+          turbo_frame: "all_floors" 
+        } do |form| %>
+
+    <div class="mt-2">
+      <%= form.check_box :show_archived_rooms, class: "form-check-input", data: { action: "input->autosubmit#search" }  %>
+      <%= form.label :show_archived_rooms, "Show Archived Rooms" %>
+    </div>
+  <% end %>
+<% end %>
+
+
 <div class="d-flex flex-row justify-content-start align-items-center gap-3">
   <h2>Rooms </h2>
   <%= link_to "Add Room", new_room_path(:building_id => @building.id), class: "mt-3 link_to" %>
 </div>
 
-<div class="accordion accordion-flush" id="buildingFloors">
-  <% @floors.each do |floor| %>
-    <div class="accordion-item">
-      <h2 class="accordion-header">
-        <button class="accordion-button collapsed bg-accordion" type="button" data-bs-toggle="collapse" data-bs-target="#collapse_<%= floor.id %>" aria-expanded="false" aria-controls="collapse_<%= floor.id %>">
-          Floor <%= floor.name %> 
-        </button>
-      </h2>
-      
-      <div id="collapse_<%= floor.id %>" class="accordion-collapse collapse" data-bs-parent="#buildingFloors">
-        <div class="accordion-body">
-          <%= turbo_frame_tag 'all_rooms' do %>  
-            <table class="table text-center">
-              <thead class="table-group-divider">
-                <tr>
-                  <th>Room Record Number</th>
-                  <th>Number</th>
-                  <th>Room Type</th>
-                  <td>View</td>
-                  <td>Remove</td>
-                </tr>
-              </thead>
-              <tbody class="table-group-divider">
-                <% floor.rooms.order(:room_number).each do |room| %>
-                  <tr class="building_tbody_tr">
-                    <td class="building_tbody_td">
-                      <%#= link_to room.room_number, room_path(room), class: "link_to" %>
-                      <%= room.rmrecnbr %>
-                    </td>
-                    <td class="building_tbody_td">
-                      <%= link_to room.room_number, room_path(room), data: { turbo_frame: "_top" }, class: "link_to" %>
-                    </td>
-                    <td class="building_tbody_td">
-                    <%= room.room_type %>
-                  </td>
-                    <td class="building_tbody_td">
-                      <%= link_to room_path(room), class: "link_to", data: { turbo_frame: "_top" } do %>
-                      <i class="bi bi-eye-fill text-primary"></i>
-                      <% end %>
-                    </td>
-                    <td class="building_tbody_td">
-                      <%= link_to "#" do %>
-                      <i class="bi bi-trash-fill text-danger"></i>
-                      <% end %>
-                    </td>
-                  </tr>
-                <% end %>
-              </tbody>
-            </table>
-          <% end %>
-        </div>
-      </div>
-    </div>
-  <% end %>
-
-</div>
+<%= render 'floors' %>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -32,15 +32,15 @@
       <%= link_to room_path(room), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Delete", data: { turbo_confirm: "Are you sure you want to delete this room?" , turbo_method: :delete } do %>
         <i class="bi bi-trash-fill text-danger"></i>
       <% end %>
-    <% end %>
-
-    <% if room.archived %>
-      <%= link_to unarchive_room_path(room), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Unarchive", data: { turbo_confirm: "Are you sure you want to unarchive this room?" , turbo_method: :post }  do %>
-        <i class="bi bi-archive text-success"></i>
-      <% end %>
     <% else %>
-      <%= link_to archive_room_path(room), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Archive", data: { turbo_confirm: "Are you sure you want to archive this room?" , turbo_method: :post }  do %>
-        <i class="bi bi-archive-fill text-success"></i>
+      <% if room.archived %>
+        <%= link_to unarchive_room_path(room), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Unarchive", data: { turbo_confirm: "Are you sure you want to unarchive this room?" , turbo_method: :post }  do %>
+          <i class="bi bi-archive text-success"></i>
+        <% end %>
+      <% else %>
+        <%= link_to archive_room_path(room), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Archive", data: { turbo_confirm: "Are you sure you want to archive this room?" , turbo_method: :post }  do %>
+          <i class="bi bi-archive-fill text-success"></i>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -26,4 +26,22 @@
     <div class="fs-5 fw-bold">Room type:</div>
     <div class="fs-5"><%= room.room_type %></div>
   </div>
+
+  <div class="py-1 d-flex flex-row align-items-center gap-3">
+    <% unless room.room_states.present? %>
+      <%= link_to room_path(room), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Delete", data: { turbo_confirm: "Are you sure you want to delete this room?" , turbo_method: :delete } do %>
+        <i class="bi bi-trash-fill text-danger"></i>
+      <% end %>
+    <% end %>
+
+    <% if room.archived %>
+      <%= link_to unarchive_room_path(room), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Unarchive", data: { turbo_confirm: "Are you sure you want to unarchive this room?" , turbo_method: :post }  do %>
+        <i class="bi bi-archive text-success"></i>
+      <% end %>
+    <% else %>
+      <%= link_to archive_room_path(room), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Archive", data: { turbo_confirm: "Are you sure you want to archive this room?" , turbo_method: :post }  do %>
+        <i class="bi bi-archive-fill text-success"></i>
+      <% end %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -3,9 +3,6 @@
     <h1>Room: <%= @room.full_name  %></h1>
     <div class="d-flex flex-column gap-1">
       <%= link_to 'Back to Building', building_path(@room.floor.building), class: "link_to" %>
-      <%= link_to room_path(@room), class: 'btn btn-danger' do %>
-        Archive <i class="bi bi-archive-fill"></i>
-      <% end %>
     </div>
   </div>
 

--- a/app/views/rover_navigations/rooms.html.erb
+++ b/app/views/rover_navigations/rooms.html.erb
@@ -37,9 +37,9 @@
       </p>
       <p style="color:red">Last Time Checked: <%= show_date_with_time(room.last_time_checked) %> </p>
       <% if RoomStatus.new(room).room_checked_today? %>
-        <%= link_to "Edit Today's Form", edit_room_room_state_path(room, RoomStatus.new(room).room_state_today.id), class: "btn btn-primary" %>
+        <%= link_to "Edit Today's #{room.room_number}", edit_room_room_state_path(room, RoomStatus.new(room).room_state_today.id), class: "btn btn-primary" %>
       <% else %>
-        <%= link_to "Start Checking Room", new_room_room_state_path(room), class: "btn btn-primary" %>
+        <%= link_to "Start Checking #{room.room_number}", new_room_room_state_path(room), class: "btn btn-primary" %>
       <% end %>
     </div>
   </div>

--- a/app/views/zones/buildings/_listing.html.erb
+++ b/app/views/zones/buildings/_listing.html.erb
@@ -38,7 +38,7 @@
           </td>
           <td class="building_tbody_td">
             <%= link_to remove_building_path(@zone, building), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Remove", data: { turbo_confirm: 'Are you sure you want to remove this building?', turbo_method: :delete} do %>
-            <i class="bi bi-trash-fill text-danger"></i>
+            <i class="bi bi-trash-fill text-primary"></i>
             <% end %>
           </td>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,8 @@ Rails.application.routes.draw do
     resources :room_states, module: :rooms
     resources :room_tickets, module: :rooms
   end
+  post 'archive_room/:id', to: 'rooms#archive', as: :archive_room
+  post 'unarchive_room/:id', to: 'rooms#unarchive', as: :unarchive_room
   resources :notes, :except => [:index]
 
   resources :floors

--- a/db/migrate/20240703164835_add_archive_field_to_room.rb
+++ b/db/migrate/20240703164835_add_archive_field_to_room.rb
@@ -1,0 +1,5 @@
+class AddArchiveFieldToRoom < ActiveRecord::Migration[7.1]
+  def change
+    add_column :rooms, :archived, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_03_042628) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_03_185321) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,6 +99,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_042628) do
     t.boolean "need_quantity_box"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "archived", default: false
   end
 
   create_table "floors", force: :cascade do |t|
@@ -173,6 +174,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_042628) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_time_checked"
+    t.boolean "archived", default: false
     t.index ["floor_id"], name: "index_rooms_on_floor_id"
   end
 

--- a/spec/factories/buildings.rb
+++ b/spec/factories/buildings.rb
@@ -13,6 +13,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  zone_id    :bigint
+#  archived   :boolean          default(FALSE)
 #
 FactoryBot.define do
   factory :building do

--- a/spec/factories/rooms.rb
+++ b/spec/factories/rooms.rb
@@ -10,6 +10,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  last_time_checked :datetime
+#  archived          :boolean          default(FALSE)
 #
 FactoryBot.define do
   factory :room do

--- a/spec/models/building_spec.rb
+++ b/spec/models/building_spec.rb
@@ -13,6 +13,7 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #  zone_id    :bigint
+#  archived   :boolean          default(FALSE)
 #
 require 'rails_helper'
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -10,6 +10,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  last_time_checked :datetime
+#  archived          :boolean          default(FALSE)
 #
 require 'rails_helper'
 

--- a/spec/system/room_controller_spec.rb
+++ b/spec/system/room_controller_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Room, type: :system do
         fill_in "Room Record Number", with: rmrecnbr
         click_on "Create Room"
         expect(page).to have_content("is not valid.")
+        expect(Room.find_by(rmrecnbr: rmrecnbr).present?).to be_falsy
       end
     end
   end
@@ -39,8 +40,70 @@ RSpec.describe Room, type: :system do
         visit "rooms/new?building_id=#{building.id}"
         fill_in "Room Record Number", with: rmrecnbr
         click_on "Create Room"
-        sleep 3
         expect(page).to have_content("Room was successfully added")
+        expect(Room.find_by(rmrecnbr: rmrecnbr).present?).to be_truthy
+      end
+    end
+  end
+
+  context 'archive a room' do
+    let!(:room) { FactoryBot.create(:room) }
+
+    it 'shows a message that room was archived' do
+      VCR.use_cassette "room" do
+        room_id = room.id
+        visit "rooms/#{room_id}"
+        accept_confirm 'Are you sure you want to archive this room?' do
+          find(:css, 'i.bi.bi-archive-fill.text-success').click
+        end
+        expect(page).to have_content("The room was archived")
+        expect(Room.find(room_id).archived == true).to be_truthy
+      end
+    end
+  end
+
+  context 'cancel archiving a room' do
+    let!(:room) { FactoryBot.create(:room) }
+
+    it 'do not shows a message that room was archived' do
+      VCR.use_cassette "room" do
+        visit "rooms/#{room.id}"
+        dismiss_confirm 'Are you sure you want to archive this room?' do
+          find(:css, 'i.bi.bi-archive-fill.text-success').click
+        end
+        expect(page).to_not have_content("The room was archived")
+        expect(room.archived == false).to be_truthy
+      end
+    end
+  end
+
+  context 'delete a room' do
+    let!(:room) { FactoryBot.create(:room) }
+
+    it 'shows that room can not be find in the database' do
+      VCR.use_cassette "room" do
+        room_id = room.id
+        visit "rooms/#{room_id}"
+        accept_confirm 'Are you sure you want to delete this room?' do
+          find(:css, 'i.bi.bi-trash-fill.text-danger').click
+        end
+        expect(page).to have_content("The room was deleted")
+        expect { Room.find(room_id) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  context 'cancel deleting a room' do
+    let!(:room) { FactoryBot.create(:room) }
+
+    it 'shows that room still exists in the database' do
+      VCR.use_cassette "room" do
+        room_id = room.id
+        visit "rooms/#{room_id}"
+        dismiss_confirm 'Are you sure you want to delete this room?' do
+          find(:css, 'i.bi.bi-trash-fill.text-danger').click
+        end
+        expect(Room.find(room_id).present?).to be_truthy
       end
     end
   end


### PR DESCRIPTION
Rooms can be archived/unarchived or deleted on the Room show page.
A room can be deleted if it has no room_states, otherwise it should be archived.
A building show page will display a Show Archived Rooms checkbox if the building has archived rooms.
Archived rooms are shown on their floors.
I added the word "archived" to a room's full_name (in the Room model)
If a room is deleted and the floor has no more rooms the floor is deleted too.



Also added

- The building's rooms are archived if a building is archived
- In the Rover form floors show only active rooms
- Scopes (active, archived) are added to Room and Floor models
- On the Building show page only one icon is displayed: delete or archive
- The Building index page will display a Show Archived Buildings checkbox if there are archived building



