### PR TITLE
Lra 964 room ready specific attribute states report

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -7,6 +7,7 @@ class ReportsController < ApplicationController
       {title: "Inspection Rate", url: inspection_rate_report_reports_path },
       {title: "No Access", url: no_access_report_reports_path },
       {title: "Common Attribute States", url: common_attribute_states_report_reports_path },
+      {title: "Specific Attribute States", url: specific_attribute_states_report_reports_path },
       {title: "Resource States", url: resource_states_report_reports_path },
     ]
   end
@@ -227,6 +228,10 @@ class ReportsController < ApplicationController
       format.html
       format.csv { send_data csv_data, filename: 'common_attribute_states_report.csv', type: 'text/csv' }
     end
+  end
+
+  def specific_attribute_states_report
+    authorize :report, :specific_attribute_states_report?
   end
 
   def resource_states_report

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -19,6 +19,10 @@ class ReportPolicy < ApplicationPolicy
     is_admin?
   end
 
+  def specific_attribute_states_report?
+    is_admin?
+  end
+
   def resource_states_report?
     is_admin?
   end

--- a/app/views/reports/specific_attribute_states_report.html.erb
+++ b/app/views/reports/specific_attribute_states_report.html.erb
@@ -1,0 +1,30 @@
+<h1>Specific Attribute States Report</h1>
+<h6>This report shows the repsonses to the Specific Questions in the Rover form.</h6>
+
+<div class="py-3">
+  <!-- turning off turbo for the form is necessary - otherwise the browser doesn't download the csv properly -->
+  <%= form_with url: specific_attribute_states_report_reports_path, method: :get, data: { turbo: false }, class: "mb-3" do |form| %>
+    <div>
+      <label for="zone_id" class="">Select a Zone</label>
+      <%= form.select :zone_id, options_for_select(@zones, selected: params[:zone_id]), {include_blank: "All Zones"}, class: "form-select" %>
+      <div class="d-flex flex-row justify-content-start align-items-center gap-3">
+        <%= form.label :from, "From: "%>
+        <%= form.date_field :from, value: params[:from], class: "form-control" %>
+        <%= form.label :to, "To: "%>
+        <%= form.date_field :to, value: params[:to], class: "form-control" %>
+      </div>
+      <div class="d-flex flex-row justify-content-start align-items-center">
+        <%= form.label :format, "Report Type: ", class: "form-label" %>
+        <%= form.select :format, options_for_select([["Display in Browser", "html"], ["Export to CSV", "csv"]],
+                                                    selected: params[:format]), {}, class: "form-select" %>
+      </div>
+    </div>
+    <div class="d-flex flex-row justify-content-start align-items-center gap-3">
+      <%= form.submit "Run Report" %>
+      <%= link_to "Clear filters", specific_attribute_states_report_reports_path, class: "text-primary cancel-button" %>
+    </div>
+  <% end %>
+  <% if params[:commit] && params[:format] == 'html' %>
+    <%= render 'reports_table' %>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
       get 'inspection_rate_report', to: 'reports#inspection_rate_report'
       get 'no_access_report', to: 'reports#no_access_report'
       get 'common_attribute_states_report', to: 'reports#common_attribute_states_report'
+      get 'specific_attribute_states_report', to: 'reports#specific_attribute_states_report'
       get 'resource_states_report', to: 'reports#resource_states_report'
     end
   end


### PR DESCRIPTION
Go to /reports and check out the Specific Attribute States report

Changes:
- added specific attribute states report
  - grouped by room
  - rows are specific attributes
  - dates are columns

Note:
- if you run a report and there is no data for those params, it will throw an error. this issue will be fixed in a separate branch because its an issue with all reports