### PR TITLE
Lra 956 room ready delete and archive specific attributes

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -78,7 +78,7 @@ class ApplicationController < ActionController::Base
     redirect = {}
 
     CommonAttribute.all.present? ? redirect["common_attributes"] = true : redirect["common_attributes"] = false
-    room.specific_attributes.present? ? redirect["specific_attributes"] = true : redirect["specific_attributes"] = false
+    room.active_specific_attributes.present? ? redirect["specific_attributes"] = true : redirect["specific_attributes"] = false
     room.resources.present? ? redirect["resources"] = true : redirect["resources"] = false
 
     new_path_to_redirect = {

--- a/app/controllers/rooms/specific_attributes_controller.rb
+++ b/app/controllers/rooms/specific_attributes_controller.rb
@@ -67,9 +67,7 @@ class Rooms::SpecificAttributesController < ApplicationController
       @specific_attributes = SpecificAttribute.active.where(room_id: @room)
       @new_specific_attribute = SpecificAttribute.new
       @archived = true
-      flash.now["notice"] = "The specific_attributes was archived"
-      # @archived = SpecificAttribute.archived.where(room_id: @room).present? ? true : false
-      # render :index, notice: "The specific attribute was archived"
+      flash.now["notice"] = "The specific attribute was archived."
     else
       render :index, status: :unprocessable_entity 
     end
@@ -80,13 +78,12 @@ class Rooms::SpecificAttributesController < ApplicationController
     if @specific_attribute.update(archived: false)
       @room = Room.find(params[:room_id])
       @specific_attributes = SpecificAttribute.archived.where(room_id: @room)
-      @new_specific_attribute = SpecificAttribute.new
+      # @new_specific_attribute = SpecificAttribute.new
       # @archived = params["show_archived_rooms"] == "1" ? true : false 
-      @archived = SpecificAttribute.archived.where(room_id: @room).present? ? true : false
-      render :index, notice: "The specific attribute was unarchived"
+      # @archived = SpecificAttribute.archived.where(room_id: @room).present? ? true : false
+      flash.now["notice"] = "The specific attribute was unarchived."
     else
-      @room = Room.find(params[:room_id])
-      @specific_attributes = SpecificAttribute.archived.where(room_id: @room)
+      render :index, status: :unprocessable_entity 
     end
   end
 
@@ -94,7 +91,7 @@ class Rooms::SpecificAttributesController < ApplicationController
     @specific_attribute.destroy!
     @room = Room.find(params[:room_id])
     @specific_attributes = SpecificAttribute.active.where(room_id: @room)
-    notice = "specific attribute was successfully deleted."
+    flash.now["notice"] = "Specific attribute was deleted."
   end
 
   private

--- a/app/controllers/rooms/specific_attributes_controller.rb
+++ b/app/controllers/rooms/specific_attributes_controller.rb
@@ -65,12 +65,23 @@ class Rooms::SpecificAttributesController < ApplicationController
     end
   end
 
+  def destroy
+    if @specific_attribute.specific_attribute_states.present?
+      @specific_attribute.update(archived: true)
+      notice = "specific attribute was successfully archived."
+    else
+      @specific_attribute.destroy!
+      specific_attributes = SpecificAttribute.where(room_id: @room)
+      notice = "specific attribute was successfully deleted."
+    end
+  end
+
   private
 
   def set_room
     @room = Room.find(params[:room_id])
   end
-    # Use callbacks to share common setup or constraints between actions.
+    # Use callbacks to share specific setup or constraints between actions.
   def set_specific_attribute
     @specific_attribute = SpecificAttribute.find(params[:id])
     authorize @specific_attribute

--- a/app/controllers/rooms/specific_attributes_controller.rb
+++ b/app/controllers/rooms/specific_attributes_controller.rb
@@ -7,7 +7,7 @@ class Rooms::SpecificAttributesController < ApplicationController
   def index
     if params["show_archived"] == "1"
       @specific_attributes = SpecificAttribute.archived.where(room_id: @room)
-      @action_title = "Unarchived"
+      @action_title = "Unarchive"
     else
       @specific_attributes = SpecificAttribute.active.where(room_id: @room)
       @action_title = "Delete/Archive"
@@ -79,9 +79,7 @@ class Rooms::SpecificAttributesController < ApplicationController
     if @specific_attribute.update(archived: false)
       @room = Room.find(params[:room_id])
       @specific_attributes = SpecificAttribute.archived.where(room_id: @room)
-      # @new_specific_attribute = SpecificAttribute.new
-      # @archived = params["show_archived_rooms"] == "1" ? true : false 
-      # @archived = SpecificAttribute.archived.where(room_id: @room).present? ? true : false
+      @action_title = "Unarchive"
       flash.now["notice"] = "The specific attribute was unarchived."
     else
       render :index, status: :unprocessable_entity 

--- a/app/controllers/rooms/specific_attributes_controller.rb
+++ b/app/controllers/rooms/specific_attributes_controller.rb
@@ -68,6 +68,7 @@ class Rooms::SpecificAttributesController < ApplicationController
       @specific_attributes = SpecificAttribute.active.where(room_id: @room)
       @new_specific_attribute = SpecificAttribute.new
       @archived = true
+      @action_title = "Delete/Archive"
       flash.now["notice"] = "The specific attribute was archived."
     else
       render :index, status: :unprocessable_entity 

--- a/app/controllers/rooms/specific_attributes_controller.rb
+++ b/app/controllers/rooms/specific_attributes_controller.rb
@@ -5,11 +5,12 @@ class Rooms::SpecificAttributesController < ApplicationController
 
   # GET /specific_attributes or /specific_attributes.json
   def index
-    
     if params["show_archived"] == "1"
       @specific_attributes = SpecificAttribute.archived.where(room_id: @room)
+      @action_title = "Unarchived"
     else
       @specific_attributes = SpecificAttribute.active.where(room_id: @room)
+      @action_title = "Delete/Archive"
     end
     @archived = SpecificAttribute.archived.where(room_id: @room).present? ? true : false
   

--- a/app/controllers/rooms/specific_attributes_controller.rb
+++ b/app/controllers/rooms/specific_attributes_controller.rb
@@ -62,7 +62,6 @@ class Rooms::SpecificAttributesController < ApplicationController
 
   # DELETE /specific_attributes/1 or /specific_attributes/1.json
   def archive
-    session[:return_to] = request.referer
     if @specific_attribute.update(archived: true)
       @room = Room.find(params[:room_id])
       @specific_attributes = SpecificAttribute.active.where(room_id: @room)
@@ -76,7 +75,6 @@ class Rooms::SpecificAttributesController < ApplicationController
   end
 
   def unarchive
-    session[:return_to] = request.referer
     if @specific_attribute.update(archived: false)
       @room = Room.find(params[:room_id])
       @specific_attributes = SpecificAttribute.archived.where(room_id: @room)

--- a/app/controllers/specific_attribute_states_controller.rb
+++ b/app/controllers/specific_attribute_states_controller.rb
@@ -15,7 +15,7 @@ class SpecificAttributeStatesController < ApplicationController
 
   # GET /specific_attribute_states/new
   def new
-    @specific_attribute_states = @room.specific_attributes.all.map do |specific_attribute|
+    @specific_attribute_states = @room.active_specific_attributes.map do |specific_attribute|
       specific_attribute.specific_attribute_states.new
     end
 

--- a/app/models/common_attribute.rb
+++ b/app/models/common_attribute.rb
@@ -8,6 +8,7 @@
 #  need_quantity_box :boolean
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  archived          :boolean          default(FALSE)
 #
 class CommonAttribute < ApplicationRecord
   has_many :common_attribute_states

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -17,6 +17,8 @@ class Room < ApplicationRecord
   has_many :resources
   has_many :room_tickets
   has_many :specific_attributes
+  has_many :active_specific_attributes, -> { active }, class_name: 'SpecificAttribute'
+  has_many :archived_specific_attributes, -> { archived }, class_name: 'SpecificAttribute'
   has_many :room_states
   has_many :notes
 

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -16,7 +16,6 @@ class Room < ApplicationRecord
   belongs_to :floor
   has_many :resources
   has_many :room_tickets
-  has_many :specific_attributes
   has_many :active_specific_attributes, -> { active }, class_name: 'SpecificAttribute'
   has_many :archived_specific_attributes, -> { archived }, class_name: 'SpecificAttribute'
   has_many :room_states

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -10,6 +10,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  last_time_checked :datetime
+#  archived          :boolean          default(FALSE)
 #
 class Room < ApplicationRecord
   belongs_to :floor

--- a/app/models/room_status.rb
+++ b/app/models/room_status.rb
@@ -11,7 +11,7 @@ class RoomStatus
   end
 
   def specific_attributes_exist?
-      @room.specific_attributes.count > 0
+      @room.active_specific_attributes.count > 0
   end
 
   def resources_exist?

--- a/app/models/specific_attribute.rb
+++ b/app/models/specific_attribute.rb
@@ -9,6 +9,7 @@
 #  room_id           :bigint           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  archived          :boolean          default(FALSE)
 #
 class SpecificAttribute < ApplicationRecord
   belongs_to :room
@@ -17,6 +18,9 @@ class SpecificAttribute < ApplicationRecord
   validates :description, presence: true
   validates :description, uniqueness: { scope: [:room_id], message: "has already been taken for this room" }
   validate :needs_either_checkbox_or_quantity_box
+
+  scope :active, -> { where(archived: false) }
+  scope :archived, -> { where(archived: true) }
 
   private
 

--- a/app/policies/specific_attribute_policy.rb
+++ b/app/policies/specific_attribute_policy.rb
@@ -22,4 +22,12 @@ class SpecificAttributePolicy < ApplicationPolicy
   def destroy?
     is_admin?
   end
+
+  def archive?
+    is_admin?
+  end
+
+  def unarchive?
+    is_admin?
+  end
 end

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -25,7 +25,7 @@
         Edit Specific Attributes <i class="bi bi-pencil-square text-primary"></i>
       <% end %>
     </div>
-    <%= render 'attributes_list', attributes: @room.specific_attributes %>
+    <%= render 'attributes_list', attributes: @room.active_specific_attributes %>
   </div>
 
   <div class="py-3 w-50">

--- a/app/views/rooms/specific_attributes/_form.html.erb
+++ b/app/views/rooms/specific_attributes/_form.html.erb
@@ -16,15 +16,17 @@
     <%= form.text_field :description, class: "form-control form-control-sm", required: true %>
   </div>
 
-  <div class="form-check mb-3">
-    <%= form.check_box :need_checkbox, class: "form-check-input" %>
-    <%= form.label :need_checkbox, "Needs Checkbox?", class: "form-check-label" %>
-  </div>
+  <% unless specific_attribute.specific_attribute_states.present? %>
+    <div class="form-check mb-3">
+      <%= form.check_box :need_checkbox, class: "form-check-input" %>
+      <%= form.label :need_checkbox, "Needs Checkbox?", class: "form-check-label" %>
+    </div>
 
-  <div class="form-check mb-3">
-    <%= form.check_box :need_quantity_box, class: "form-check-input" %>
-    <%= form.label :need_quantity_box, "Needs Quantity Box?", class: "form-check-label" %>
-  </div>
+    <div class="form-check mb-3">
+      <%= form.check_box :need_quantity_box, class: "form-check-input" %>
+      <%= form.label :need_quantity_box, "Needs Quantity Box?", class: "form-check-label" %>
+    </div>
+  <% end %>
 
   <div class="d-flex flex-row justify-content-start align-items-center gap-3">
     <%= form.submit specific_attribute.persisted? ? 'Update' : 'Create', class: "btn btn-primary" %>

--- a/app/views/rooms/specific_attributes/_show_archived.html.erb
+++ b/app/views/rooms/specific_attributes/_show_archived.html.erb
@@ -1,0 +1,17 @@
+<%= turbo_frame_tag 'show_archived' do %>
+  <%= @archived %> - archived
+  <% if @archived %>
+    <%= form_with url: room_specific_attributes_path, method: :get, class: "", 
+      data: { 
+        controller: "autosubmit", 
+        autosubmit_target: "form", 
+        turbo_frame: "specific_attributes_list" 
+      } do |form| %>
+
+      <div class="mt-2">
+        <%= check_box_tag :show_archived, 1, params["show_archived"], class: "form-check-input", data: { action: "input->autosubmit#search" }  %>
+        <%= form.label :show_archived, "Show Archived Specific Atributes" %>
+      </div>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/rooms/specific_attributes/_show_archived.html.erb
+++ b/app/views/rooms/specific_attributes/_show_archived.html.erb
@@ -1,13 +1,11 @@
 <%= turbo_frame_tag 'show_archived' do %>
-  <%= @archived %> - archived
   <% if @archived %>
     <%= form_with url: room_specific_attributes_path, method: :get, class: "", 
       data: { 
         controller: "autosubmit", 
         autosubmit_target: "form", 
-        turbo_frame: "specific_attributes_list" 
+        turbo_frame: "specific_attributes_list"
       } do |form| %>
-
       <div class="mt-2">
         <%= check_box_tag :show_archived, 1, params["show_archived"], class: "form-check-input", data: { action: "input->autosubmit#search" }  %>
         <%= form.label :show_archived, "Show Archived Specific Atributes" %>

--- a/app/views/rooms/specific_attributes/_specific_attribute.html.erb
+++ b/app/views/rooms/specific_attributes/_specific_attribute.html.erb
@@ -16,8 +16,20 @@
     <% end %>
   </td>
   <td>
-    <%= link_to room_specific_attribute_path(@room, specific_attribute), data: { turbo_confirm: "Are you sure you want to delete this specific attribute?" , turbo_method: :delete } do %>
-      <i class="bi bi-trash-fill text-danger"></i>
+    <% if specific_attribute.archived %> 
+      <%= link_to unarchive_specific_attribute_path(specific_attribute), 'aria-label': "unarchive_#{specific_attribute.id}" do %> 
+        <i class="bi bi-archive text-success"></i> 
+      <% end %> 
+    <% else %> 
+      <% if specific_attribute.specific_attribute_states.present? %> 
+        <%= link_to unarchive_specific_attribute_path(@room, specific_attribute), 'aria-label': "delete_#{specific_attribute.id}", data: { turbo_confirm: "Are you sure you want to archive this specific attribute?" , turbo_method: :delete } do %> 
+          <i class="bi bi-archive-fill text-success"></i> 
+        <% end %> 
+      <% else %> 
+        <%= link_to room_specific_attribute_path(@room, specific_attribute), 'aria-label': "delete_#{specific_attribute.id}", data: { turbo_confirm: "Are you sure you want to delete this specific attribute?" , turbo_method: :delete } do %> 
+          <i class="bi bi-trash-fill text-danger"></i> 
+        <% end %> 
+      <% end %> 
     <% end %>
   </td>
 </tr>

--- a/app/views/rooms/specific_attributes/_specific_attribute.html.erb
+++ b/app/views/rooms/specific_attributes/_specific_attribute.html.erb
@@ -11,7 +11,7 @@
     <% end %>
   </td>
   <td>
-    <%= link_to edit_room_specific_attribute_path(@room, specific_attribute) do %>
+    <%= link_to edit_room_specific_attribute_path(@room, specific_attribute), data: { turbo_frame: "_top" } do %>
       <i class="bi bi-pencil-square text-primary"></i>
     <% end %>
   </td>

--- a/app/views/rooms/specific_attributes/_specific_attribute.html.erb
+++ b/app/views/rooms/specific_attributes/_specific_attribute.html.erb
@@ -11,22 +11,22 @@
     <% end %>
   </td>
   <td>
-    <%= link_to edit_room_specific_attribute_path(@room, specific_attribute), data: { turbo_frame: "_top" } do %>
+    <%= link_to edit_room_specific_attribute_path(@room, specific_attribute), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Edit", data: { turbo_frame: "_top" } do %>
       <i class="bi bi-pencil-square text-primary"></i>
     <% end %>
   </td>
   <td>
     <% if specific_attribute.archived %> 
-      <%= link_to unarchive_specific_attribute_path(@room, specific_attribute), 'aria-label': "unarchive_#{specific_attribute.id}", data: { turbo_confirm: "Are you sure you want to unarchive this specific attribute?" , turbo_method: :post } do %> 
+      <%= link_to unarchive_specific_attribute_path(@room, specific_attribute), 'aria-label': "unarchive_#{specific_attribute.id}", 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Unarchive", data: { turbo_confirm: "Are you sure you want to unarchive this specific attribute?" , turbo_method: :post } do %> 
         <i class="bi bi-archive text-success"></i> 
       <% end %> 
     <% else %> 
       <% if specific_attribute.specific_attribute_states.present? %> 
-        <%= link_to archive_specific_attribute_path(@room, specific_attribute), 'aria-label': "archive_#{specific_attribute.id}", data: { turbo_confirm: "Are you sure you want to archive this specific attribute?" , turbo_method: :post } do %> 
+        <%= link_to archive_specific_attribute_path(@room, specific_attribute), 'aria-label': "archive_#{specific_attribute.id}", 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Archive", data: { turbo_confirm: "Are you sure you want to archive this specific attribute?" , turbo_method: :post } do %> 
           <i class="bi bi-archive-fill text-success"></i> 
         <% end %> 
       <% else %> 
-        <%= link_to room_specific_attribute_path(@room, specific_attribute), 'aria-label': "delete_#{specific_attribute.id}", data: { turbo_confirm: "Are you sure you want to delete this specific attribute?" , turbo_method: :delete } do %> 
+        <%= link_to room_specific_attribute_path(@room, specific_attribute), 'aria-label': "delete_#{specific_attribute.id}", 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Delete", data: { turbo_confirm: "Are you sure you want to delete this specific attribute?" , turbo_method: :delete } do %> 
           <i class="bi bi-trash-fill text-danger"></i> 
         <% end %> 
       <% end %> 

--- a/app/views/rooms/specific_attributes/_specific_attribute.html.erb
+++ b/app/views/rooms/specific_attributes/_specific_attribute.html.erb
@@ -11,8 +11,10 @@
     <% end %>
   </td>
   <td>
-    <%= link_to edit_room_specific_attribute_path(@room, specific_attribute), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Edit", data: { turbo_frame: "_top" } do %>
-      <i class="bi bi-pencil-square text-primary"></i>
+    <% unless specific_attribute.archived %>
+      <%= link_to edit_room_specific_attribute_path(@room, specific_attribute), 'data-bs-toggle': "tooltip", 'data-bs-placement': "bottom", 'title': "Edit", data: { turbo_frame: "_top" } do %>
+        <i class="bi bi-pencil-square text-primary"></i>
+      <% end %>
     <% end %>
   </td>
   <td>

--- a/app/views/rooms/specific_attributes/_specific_attribute.html.erb
+++ b/app/views/rooms/specific_attributes/_specific_attribute.html.erb
@@ -17,12 +17,12 @@
   </td>
   <td>
     <% if specific_attribute.archived %> 
-      <%= link_to unarchive_specific_attribute_path(specific_attribute), 'aria-label': "unarchive_#{specific_attribute.id}" do %> 
+      <%= link_to unarchive_specific_attribute_path(@room, specific_attribute), 'aria-label': "unarchive_#{specific_attribute.id}", data: { turbo_confirm: "Are you sure you want to unarchive this specific attribute?" , turbo_method: :post } do %> 
         <i class="bi bi-archive text-success"></i> 
       <% end %> 
     <% else %> 
       <% if specific_attribute.specific_attribute_states.present? %> 
-        <%= link_to unarchive_specific_attribute_path(@room, specific_attribute), 'aria-label': "delete_#{specific_attribute.id}", data: { turbo_confirm: "Are you sure you want to archive this specific attribute?" , turbo_method: :delete } do %> 
+        <%= link_to archive_specific_attribute_path(@room, specific_attribute), 'aria-label': "archive_#{specific_attribute.id}", data: { turbo_confirm: "Are you sure you want to archive this specific attribute?" , turbo_method: :post } do %> 
           <i class="bi bi-archive-fill text-success"></i> 
         <% end %> 
       <% else %> 

--- a/app/views/rooms/specific_attributes/_specific_attributes_list.html.erb
+++ b/app/views/rooms/specific_attributes/_specific_attributes_list.html.erb
@@ -6,11 +6,7 @@
       <th scope="col">Needs Checkbox?</th>
       <th scope="col">Needs Quantity Box?</th>
       <th scope="col">Edit</th>
-      <% if @archived %>
-        <th scope="col">Unarchive</th>
-      <% else %>
-        <th scope="col">Delete/Archive</th>
-      <% end %>
+      <th scope="col"><%= @action_title %></th>
     </tr>
     </thead>
     <tbody class="table-group-divider" id="specific_attributes">

--- a/app/views/rooms/specific_attributes/_specific_attributes_list.html.erb
+++ b/app/views/rooms/specific_attributes/_specific_attributes_list.html.erb
@@ -1,0 +1,22 @@
+<%= turbo_frame_tag 'specific_attributes_list' do %>
+  <table class="table text-center mt-4">
+    <thead class="table-group-divider">
+    <tr>
+      <th scope="col" class="text-start">Description</th>
+      <th scope="col">Needs Checkbox?</th>
+      <th scope="col">Needs Quantity Box?</th>
+      <th scope="col">Edit</th>
+      <% if @archived %>
+      <th scope="col">Unarchive <%= @archived %></th>
+      <% else %>
+        <th scope="col">Delete/Archive <%= @archived %></th>
+      <% end %>
+    </tr>
+    </thead>
+    <tbody class="table-group-divider" id="specific_attributes">
+    <% @specific_attributes.each do |specific_attribute| %>
+      <%= render specific_attribute %>
+    <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/rooms/specific_attributes/_specific_attributes_list.html.erb
+++ b/app/views/rooms/specific_attributes/_specific_attributes_list.html.erb
@@ -7,9 +7,9 @@
       <th scope="col">Needs Quantity Box?</th>
       <th scope="col">Edit</th>
       <% if @archived %>
-      <th scope="col">Unarchive <%= @archived %></th>
+        <th scope="col">Unarchive</th>
       <% else %>
-        <th scope="col">Delete/Archive <%= @archived %></th>
+        <th scope="col">Delete/Archive</th>
       <% end %>
     </tr>
     </thead>

--- a/app/views/rooms/specific_attributes/archive.turbo_stream.erb
+++ b/app/views/rooms/specific_attributes/archive.turbo_stream.erb
@@ -1,3 +1,6 @@
+<%= turbo_stream.update "show_archived" do %>
+  <%= render 'show_archived' %>
+<% end %>
 <%= turbo_stream.update "specific_attributes_list" do %>
   <%= render "specific_attributes_list" %>
 <% end %>

--- a/app/views/rooms/specific_attributes/destroy.turbo_stream.erb
+++ b/app/views/rooms/specific_attributes/destroy.turbo_stream.erb
@@ -1,2 +1,3 @@
-<%= turbo_stream.remove @specific_attribute %>
+<%= turbo_stream.update 'specific_attributes_list' %>
+
 <%= turbo_stream.update "flash", partial: 'layouts/flash' %>

--- a/app/views/rooms/specific_attributes/index.html.erb
+++ b/app/views/rooms/specific_attributes/index.html.erb
@@ -8,22 +8,7 @@
     <%= render 'form', specific_attribute: @new_specific_attribute %>
   <% end %>
 
-  <%= turbo_frame_tag 'specific_attributes_list' do %>
-    <table class="table text-center mt-4">
-      <thead class="table-group-divider">
-      <tr>
-        <th scope="col" class="text-start">Description</th>
-        <th scope="col">Needs Checkbox?</th>
-        <th scope="col">Needs Quantity Box?</th>
-        <th scope="col">Edit</th>
-        <th scope="col">Delete/Archive</th>
-      </tr>
-      </thead>
-      <tbody class="table-group-divider" id="specific_attributes">
-      <% @specific_attributes.each do |specific_attribute| %>
-        <%= render specific_attribute %>
-      <% end %>
-      </tbody>
-    </table>
-  <% end %>
+  <%= render 'show_archived' %>
+  <%= render 'specific_attributes_list' %>
+    
 </div>

--- a/app/views/rooms/specific_attributes/index.html.erb
+++ b/app/views/rooms/specific_attributes/index.html.erb
@@ -1,6 +1,6 @@
 <div class="py-3">
   <div class="mb-3 d-flex flex-row align-items-center justify-content-between">
-    <h1>Specific Attributes</h1>
+    <h1>Specific Attributes - <%= @room.room_number %> Room</h1>
     <%= link_to "Back to Room", room_path(@room), class: "link_to" %>
   </div>
 

--- a/app/views/rooms/specific_attributes/index.html.erb
+++ b/app/views/rooms/specific_attributes/index.html.erb
@@ -8,20 +8,22 @@
     <%= render 'form', specific_attribute: @new_specific_attribute %>
   <% end %>
 
-  <table class="table text-center mt-4">
-    <thead class="table-group-divider">
-    <tr>
-      <th scope="col" class="text-start">Description</th>
-      <th scope="col">Needs Checkbox?</th>
-      <th scope="col">Needs Quantity Box?</th>
-      <th scope="col">Edit</th>
-      <th scope="col">Delete</th>
-    </tr>
-    </thead>
-    <tbody class="table-group-divider" id="specific_attributes">
-    <% @specific_attributes.each do |specific_attribute| %>
-      <%= render specific_attribute %>
-    <% end %>
-    </tbody>
-  </table>
+  <%= turbo_frame_tag 'specific_attributes_list' do %>
+    <table class="table text-center mt-4">
+      <thead class="table-group-divider">
+      <tr>
+        <th scope="col" class="text-start">Description</th>
+        <th scope="col">Needs Checkbox?</th>
+        <th scope="col">Needs Quantity Box?</th>
+        <th scope="col">Edit</th>
+        <th scope="col">Delete/Archive</th>
+      </tr>
+      </thead>
+      <tbody class="table-group-divider" id="specific_attributes">
+      <% @specific_attributes.each do |specific_attribute| %>
+        <%= render specific_attribute %>
+      <% end %>
+      </tbody>
+    </table>
+  <% end %>
 </div>

--- a/app/views/rooms/specific_attributes/unarchive.turbo_stream.erb
+++ b/app/views/rooms/specific_attributes/unarchive.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.update "specific_attributes_list" do %>
+  <%= render "specific_attributes_list" %>
+<% end %>
+
+<%= render_flash_stream %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,7 +48,8 @@ Rails.application.routes.draw do
   post 'archive_room/:id', to: 'rooms#archive', as: :archive_room
   post 'unarchive_room/:id', to: 'rooms#unarchive', as: :unarchive_room
   resources :notes, :except => [:index]
-  get 'unarchive_specific_attribute/:room_id/:id', to: 'rooms/common_attributes#unarchive', as: :unarchive_specific_attribute
+  post 'archive_specific_attribute/:room_id/:id', to: 'rooms/specific_attributes#archive', as: :archive_specific_attribute
+  post 'unarchive_specific_attribute/:room_id/:id', to: 'rooms/specific_attributes#unarchive', as: :unarchive_specific_attribute
 
   resources :floors
   resources :buildings do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
     resources :room_tickets, module: :rooms
   end
   resources :notes, :except => [:index]
+  get 'unarchive_specific_attribute/:room_id/:id', to: 'rooms/common_attributes#unarchive', as: :unarchive_specific_attribute
 
   resources :floors
   resources :buildings do

--- a/db/migrate/20240705032138_add_archived_field_to_spechfic_attribute.rb
+++ b/db/migrate/20240705032138_add_archived_field_to_spechfic_attribute.rb
@@ -1,0 +1,5 @@
+class AddArchivedFieldToSpechficAttribute < ActiveRecord::Migration[7.1]
+  def change
+    add_column :specific_attributes, :archived, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_03_042628) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_05_032138) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -99,6 +99,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_042628) do
     t.boolean "need_quantity_box"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "archived", default: false
   end
 
   create_table "floors", force: :cascade do |t|
@@ -173,6 +174,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_042628) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "last_time_checked"
+    t.boolean "archived", default: false
     t.index ["floor_id"], name: "index_rooms_on_floor_id"
   end
 
@@ -202,6 +204,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_042628) do
     t.bigint "room_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "archived", default: false
     t.index ["room_id"], name: "index_specific_attributes_on_room_id"
   end
 

--- a/spec/factories/common_attributes.rb
+++ b/spec/factories/common_attributes.rb
@@ -8,6 +8,7 @@
 #  need_quantity_box :boolean
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  archived          :boolean          default(FALSE)
 #
 FactoryBot.define do
   factory :common_attribute do

--- a/spec/factories/rooms.rb
+++ b/spec/factories/rooms.rb
@@ -10,6 +10,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  last_time_checked :datetime
+#  archived          :boolean          default(FALSE)
 #
 FactoryBot.define do
   factory :room do

--- a/spec/factories/specific_attributes.rb
+++ b/spec/factories/specific_attributes.rb
@@ -9,6 +9,7 @@
 #  room_id           :bigint           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  archived          :boolean          default(FALSE)
 #
 FactoryBot.define do
   factory :specific_attribute do

--- a/spec/models/common_attribute_spec.rb
+++ b/spec/models/common_attribute_spec.rb
@@ -8,6 +8,7 @@
 #  need_quantity_box :boolean
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  archived          :boolean          default(FALSE)
 #
 require 'rails_helper'
 

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -10,6 +10,7 @@
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  last_time_checked :datetime
+#  archived          :boolean          default(FALSE)
 #
 require 'rails_helper'
 

--- a/spec/models/specific_attribute_spec.rb
+++ b/spec/models/specific_attribute_spec.rb
@@ -9,6 +9,7 @@
 #  room_id           :bigint           not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
+#  archived          :boolean          default(FALSE)
 #
 require 'rails_helper'
 


### PR DESCRIPTION
To archive/delete specific attributes go to Buildings->Select a building->Select a floor-> Select a room
Click on Edit Specific Attributes.
If an attribute has no saved stated - it can be deleted, otherwise - archived. The correspondent icon is displayed in the attribute’s row.

If you don’t have attributes to delete - create a new one and test deleting it.
If you don’t have icons to archive - go to rover form and check this room.
If you don’t have any specific attributes - create some.

To see archived attributes - click on the Show Archived Specific Attributes checkbox. It is displayed if the room has achieved specific attributes.
Click again to see active attributes.

You can unarchive an attribute from the list of archived attributes.
You can not edit archived attributes.