### PR TITLE
Lra 969 room ready show last RoomUpdateLog entry

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -19,6 +19,8 @@ class StaticPagesController < ApplicationController
 
   def dashboard
     authorize :static_page
+    @room_update_log = RoomUpdateLog.last
+
     @selected_date = params[:dashboard_date].present? ? Date.parse(params[:dashboard_date]) : Date.today
 
     @latest_tickets = latest_room_tickets

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -55,4 +55,7 @@ module DashboardHelper
         .count
   end
 
+  def room_update_log_status(log_note)
+    log_note.split("|").first.strip
+  end
 end

--- a/app/views/static_pages/_last_room_update_log.html.erb
+++ b/app/views/static_pages/_last_room_update_log.html.erb
@@ -29,8 +29,7 @@
             </div>
           </div>
         <% elsif room_update_log_status(last_room_update_log.note) == 'error' %>
-          An error occurred while updating resources for rooms.
-          <a class="text-primary" href="#myCustomTrigger">Report an issue.</a>
+          An error occurred while updating resources for rooms. Please report an issue.
         <% end %>
       </h6>
     </div>

--- a/app/views/static_pages/_last_room_update_log.html.erb
+++ b/app/views/static_pages/_last_room_update_log.html.erb
@@ -1,0 +1,38 @@
+<div class="col-lg-4 col-md-6 col-sm-12 mb-3">
+  <div class="card">
+    <div class="card-header">
+      <h3>Resources Script</h3>
+    </div>
+    <div class="card-body">
+      <h6 class="card-text mb-4">Last Run at: <%= show_date_with_time(last_room_update_log.created_at) %></h6>
+      <h6 class="card-text mb-4">
+        Status:
+        <span
+          class="<%= room_update_log_status(last_room_update_log.note) == 'error' ? 'text-danger' : 'text-success' %>">
+          <%= last_room_update_log.note.include?('success') ? 'SUCCESS' : 'ERROR' %>
+        </span>
+      </h6>
+
+      <h6 class="card-text mb-4">
+        Note:
+        <% if room_update_log_status(last_room_update_log.note) == 'success' %>
+          Resources updated successfully for rooms.
+        <% elsif room_update_log_status(last_room_update_log.note) == 'success-partial' %>
+          Resources updated successfully for rooms.
+          <a class="text-primary" data-bs-toggle="collapse" href="#nonExistingRooms" role="button" aria-expanded="false" aria-controls="nonExistingRooms">
+            These
+          </a>
+          rooms (rmrecnbr) don't exist in WebCheckout.
+          <div class="collapse" id="nonExistingRooms">
+            <div class="card card-body">
+              <%= last_room_update_log.note.split(':').last.strip %>
+            </div>
+          </div>
+        <% elsif room_update_log_status(last_room_update_log.note) == 'error' %>
+          An error occurred while updating resources for rooms.
+          <a class="text-primary" href="#myCustomTrigger">Report an issue.</a>
+        <% end %>
+      </h6>
+    </div>
+  </div>
+</div>

--- a/app/views/static_pages/dashboard.html.erb
+++ b/app/views/static_pages/dashboard.html.erb
@@ -16,7 +16,7 @@
       </div>
     <% end %>
 
-  
+
   <h2>Zone Overview</h2>
   <div class="row">    
     <% @zones.each do |zone| %>
@@ -87,5 +87,9 @@
       </div>
     <% end %>
   </div>
-<hr>
+  <hr>
+  <h2>Daily Resource Update Script</h2>
+  <% if @room_update_log %>
+    <%= render 'last_room_update_log', last_room_update_log: @room_update_log %>
+  <% end %>
 </div>

--- a/lib/tasks/update_resources.rake
+++ b/lib/tasks/update_resources.rake
@@ -59,18 +59,18 @@ task update_resources: :environment do
       end
     end
 
-    raise "Transaction failed, error updating resources: #{transaction_error.message}" unless transaction_succeeded
+    raise "Transaction failed, error updating resources: #{transaction_error}" unless transaction_succeeded
 
     if rooms_to_update.any?
       # these rooms were not updated because they don't eexist in wco
       list = Room.where(rmrecnbr: rooms_to_update).pluck(:rmrecnbr).join(", ")
       note = "Resources updated successfully for rooms. The following rooms don't exist in WebCheckout database: #{list}"
-      RoomUpdateLog.create(date: Date.today, note: note)
+      RoomUpdateLog.create(date: Date.today, note: "success-partial | #{note}")
     else
-      RoomUpdateLog.create(date: Date.today, note: "Resources updated successfully for all rooms")
+      RoomUpdateLog.create(date: Date.today, note: "success | Resources updated successfully for all rooms")
     end
   rescue StandardError => e
-    RoomUpdateLog.create(date: Date.today, note: e)
+    RoomUpdateLog.create(date: Date.today, note: "error | #{e}")
   end
 end
 


### PR DESCRIPTION
Changes:
- added a card that shows the status of the last resources script run. statuses are:
  - `success`
  - `success-partial` also shows a dropdown of rmrecnbrs of rooms that dont exist in WCO
  - `error` shows a link to navigate to the footer (to report an issue)

To test all cases, go to `lib/tasks/update_resources.rake`, change line 64 that says `if rooms_to_update.any?` to the cases below, and run `rake update_resources`:
- change it to `if [].hello` to check `error` status
- change it to `if false` to check `success` status
- keep it as is to check `success-partial` status

Question:
- is the location where I put this fine (in the dashboard)? or is there a better place to put it