### PR TITLE
LRA-970-add-continue-checking-button-if-the-room-is-halfway-being-checked

### DIFF
--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,6 +1,6 @@
 class RoomsController < ApplicationController
   before_action :auth_user
-  before_action :set_room, only: %i[ show destroy archive unarchive ]
+  before_action :set_room, only: %i[ show destroy archive unarchive redirect_to_unchecked_form ]
   include BuildingApi
 
   # GET /rooms or /rooms.json
@@ -83,6 +83,22 @@ class RoomsController < ApplicationController
       redirect_back_or_default(notice: "The room was unarchived")
     else
       @rooms = Room.archived.order(:name)
+    end
+  end
+
+  def redirect_to_unchecked_form
+    room_state = RoomStatus.new(@room).room_state_today
+    if room_state.common_attribute_states.any?
+      if room_state.specific_attribute_states.any?
+        if room_state.resource_states.any?
+        else
+          redirect_to redirect_rover_to_correct_state(room: @room, room_state: room_state, step: "specific_attributes", mode: "new") 
+        end 
+      else 
+        redirect_to redirect_rover_to_correct_state(room: @room, room_state: room_state, step: "common_attributes", mode: "new")
+      end
+    else
+      redirect_to redirect_rover_to_correct_state(room: @room, room_state: room_state, step: "room", mode: "new")
     end
   end
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,6 +1,6 @@
 class RoomsController < ApplicationController
   before_action :auth_user
-  before_action :set_room, only: %i[ show destroy archive unarchive redirect_to_unchecked_form ]
+  before_action :set_room, only: %i[ show destroy archive unarchive ]
   include BuildingApi
 
   # GET /rooms or /rooms.json
@@ -83,22 +83,6 @@ class RoomsController < ApplicationController
       redirect_back_or_default(notice: "The room was unarchived")
     else
       @rooms = Room.archived.order(:name)
-    end
-  end
-
-  def redirect_to_unchecked_form
-    room_state = RoomStatus.new(@room).room_state_today
-    if room_state.common_attribute_states.any?
-      if room_state.specific_attribute_states.any?
-        if room_state.resource_states.any?
-        else
-          redirect_to redirect_rover_to_correct_state(room: @room, room_state: room_state, step: "specific_attributes", mode: "new") 
-        end 
-      else 
-        redirect_to redirect_rover_to_correct_state(room: @room, room_state: room_state, step: "common_attributes", mode: "new")
-      end
-    else
-      redirect_to redirect_rover_to_correct_state(room: @room, room_state: room_state, step: "room", mode: "new")
     end
   end
 

--- a/app/controllers/rover_navigations_controller.rb
+++ b/app/controllers/rover_navigations_controller.rb
@@ -27,6 +27,24 @@ class RoverNavigationsController < ApplicationController
     end
   end
 
+  def redirect_to_unchecked_form
+    room = Room.find(params[:id])
+    authorize :rover_navigation
+    room_state = RoomStatus.new(room).room_state_today
+    if room_state.common_attribute_states.any?
+      if room_state.specific_attribute_states.any?
+        if room_state.resource_states.any?
+        else
+          redirect_to redirect_rover_to_correct_state(room: room, room_state: room_state, step: "specific_attributes", mode: "new") 
+        end 
+      else 
+        redirect_to redirect_rover_to_correct_state(room: room, room_state: room_state, step: "common_attributes", mode: "new")
+      end
+    else
+      redirect_to redirect_rover_to_correct_state(room: room, room_state: room_state, step: "room", mode: "new")
+    end
+  end
+
   def confirmation
     authorize :rover_navigation, :confirmation?
     @room = Room.find(params[:room_id])

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -27,7 +27,4 @@ class RoomPolicy < ApplicationPolicy
     is_admin?
   end
 
-  def redirect_to_unchecked_form?
-    is_admin? || is_rover?
-  end
 end

--- a/app/policies/room_policy.rb
+++ b/app/policies/room_policy.rb
@@ -26,4 +26,8 @@ class RoomPolicy < ApplicationPolicy
   def unarchive?
     is_admin?
   end
+
+  def redirect_to_unchecked_form?
+    is_admin? || is_rover?
+  end
 end

--- a/app/policies/rover_navigation_policy.rb
+++ b/app/policies/rover_navigation_policy.rb
@@ -14,4 +14,9 @@ class RoverNavigationPolicy < ApplicationPolicy
   def confirmation?
     is_rover? || is_admin?
   end
+
+  def redirect_to_unchecked_form?
+    is_rover? || is_admin?
+  end
+
 end

--- a/app/views/rover_navigations/rooms.html.erb
+++ b/app/views/rover_navigations/rooms.html.erb
@@ -37,7 +37,11 @@
       </p>
       <p style="color:red">Last Time Checked: <%= show_date_with_time(room.last_time_checked) %> </p>
       <% if RoomStatus.new(room).room_checked_today? %>
-        <%= link_to "Edit Today's #{room.room_number}", edit_room_room_state_path(room, RoomStatus.new(room).room_state_today.id), class: "btn btn-primary" %>
+        <% if RoomStatus.new(room).calculate_percentage.to_f < 100.00 %>
+          <%= link_to "Continue Checking #{room.room_number}", redirect_to_unchecked_form_path(room), class: "btn btn-primary" %>
+        <% else %>
+          <%= link_to "Edit Today's #{room.room_number}", edit_room_room_state_path(room, RoomStatus.new(room).room_state_today.id), class: "btn btn-primary" %>
+        <% end %>
       <% else %>
         <%= link_to "Start Checking #{room.room_number}", new_room_room_state_path(room), class: "btn btn-primary" %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,8 @@ Rails.application.routes.draw do
 
   post '/send_email_for_tdx_ticket/:room_id', to: 'rooms/room_tickets#send_email_for_tdx_ticket', as: :send_email_for_tdx_ticket
 
+  get '/redirect_to_unchecked_form/:id', to: 'rooms#redirect_to_unchecked_form', as: :redirect_to_unchecked_form
+
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development? || Rails.env.staging?
 
   # Place this at the very end of the file to catch all undefined routes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,9 @@ Rails.application.routes.draw do
     end
   end
 
+  get 'redirect_to_unchecked_form/:id', to: 'rover_navigations#redirect_to_unchecked_form', as: :redirect_to_unchecked_form
+
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
@@ -90,8 +93,6 @@ Rails.application.routes.draw do
   get 'welcome_rovers', to: 'static_pages#welcome_rovers', as: :welcome_rovers
 
   post '/send_email_for_tdx_ticket/:room_id', to: 'rooms/room_tickets#send_email_for_tdx_ticket', as: :send_email_for_tdx_ticket
-
-  get '/redirect_to_unchecked_form/:id', to: 'rooms#redirect_to_unchecked_form', as: :redirect_to_unchecked_form
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development? || Rails.env.staging?
 


### PR DESCRIPTION
If the room check process is incomplete, the rover navigation page button will show 'Continue Checking <room number>' instead of 'Edit ...'  and by clicking the button rovers will be redirected to the first empty form.
