### PR TITLE
LRA-911 hide new common attribute form with accordion style

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :timeoutable,
          :recoverable, :rememberable, :validatable,
          :omniauthable, omniauth_providers: [:saml]
 

--- a/app/views/common_attributes/index.html.erb
+++ b/app/views/common_attributes/index.html.erb
@@ -1,9 +1,22 @@
 <div class="px-5 py-3">
   <h1 class="mb-3">Common Attributes</h1>
 
-  <%= turbo_frame_tag 'new_common_attribute_form' do %>
-    <%= render 'form', common_attribute: @new_common_attribute %>
-  <% end %>
+  <div class="accordion" id="newForm">
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="headingOne">
+        <button class="accordion-button collapsed bg-accordion" type="button" data-bs-toggle="collapse" data-bs-target="#collapseNewForm" aria-expanded="false" aria-controls="collapseNewForm">
+        Create New Common Attribute
+        </button>
+      </h2>
+      <div id="collapseNewForm" class="accordion-collapse collapse" aria-labelledby="headingOne" data-bs-parent="#newForm">
+        <div class="accordion-body">
+          <%= turbo_frame_tag 'new_common_attribute_form' do %>
+            <%= render 'form', common_attribute: @new_common_attribute %>
+          <% end %>        
+        </div>
+      </div>
+    </div>
+  </div>
 
   <%= form_with(url: common_attributes_path, html: { class: 'mb-3' }, method: :get, data: { controller: "autosubmit", autosubmit_target: "form" }) do |form| %>
     <div class="mt-2">

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -18,12 +18,12 @@
   </div>
 
   <div class="py-1 d-flex flex-row align-items-center gap-3">
-    <div class="fs-5 fw-bold">Room number: </div>
+    <div class="fs-5 fw-bold">Room Number: </div>
     <div class="fs-5"><%= room.room_number %></div>
   </div>
 
   <div class="py-1 d-flex flex-row align-items-center gap-3">
-    <div class="fs-5 fw-bold">Room type:</div>
+    <div class="fs-5 fw-bold">Room Type:</div>
     <div class="fs-5"><%= room.room_type %></div>
   </div>
 


### PR DESCRIPTION
Maria commented that "On the [Common Attribute show page](https://roomready-staging.lsa.umich.edu/common_attributes), it’s little confusing to come to this page and immediately be offered an action to create one. Can we create an accordion title Create New Attribute that holds the create form?"

Add :timeoutable setting to the User model.

Please look at the page now and check that creating a new Common Attreibite works fine.


